### PR TITLE
[#30] refactor: Events 객체 생성자 방어와 User Domain 임시 변수 제거(Sonar Issue)

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/aop/event/Events.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/aop/event/Events.java
@@ -1,8 +1,11 @@
 package com.todaysfail.aop.event;
 
+import lombok.NoArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class Events {
+
     private static ThreadLocal<ApplicationEventPublisher> publisherLocal = new ThreadLocal<>();
 
     public static void raise(DomainEvent event) {

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/User.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/User.java
@@ -1,8 +1,10 @@
 package com.todaysfail.domains.user.domain;
 
+import com.todaysfail.aop.event.Events;
 import com.todaysfail.common.type.user.AccountRole;
 import com.todaysfail.common.type.user.AccountStatus;
 import com.todaysfail.domains.user.entity.UserEntity;
+import com.todaysfail.events.UserRegisterEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,6 +37,7 @@ public class User {
                         OauthInfo.of(userEntity.getProvider(), userEntity.getOid()),
                         userEntity.getAccountStatus(),
                         userEntity.getAccountRole());
+        Events.raise(new UserRegisterEvent(userEntity.getId()));
         return user;
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserRegisterService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserRegisterService.java
@@ -1,13 +1,13 @@
 package com.todaysfail.domains.user.service;
 
-import com.todaysfail.aop.event.Events;
+import com.todaysfail.common.type.user.AccountRole;
+import com.todaysfail.common.type.user.AccountStatus;
 import com.todaysfail.domains.user.domain.OauthInfo;
 import com.todaysfail.domains.user.domain.Profile;
 import com.todaysfail.domains.user.domain.User;
 import com.todaysfail.domains.user.entity.UserEntity;
 import com.todaysfail.domains.user.port.UserCommandPort;
 import com.todaysfail.domains.user.usecase.UserRegisterUseCase;
-import com.todaysfail.events.UserRegisterEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,8 +22,11 @@ public class UserRegisterService implements UserRegisterUseCase {
     public User execute(Profile profile, OauthInfo oauthInfo) {
         UserEntity userEntity =
                 userCommandPort.registerUser(
-                        profile.getName(), oauthInfo.getProvider(), oauthInfo.getOid());
-        Events.raise(new UserRegisterEvent(userEntity.getId()));
+                        profile.getName(),
+                        oauthInfo.getProvider(),
+                        oauthInfo.getOid(),
+                        AccountStatus.NORMAL,
+                        AccountRole.USER);
         return User.registerUser(userEntity);
     }
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/adapter/UserCommandAdapter.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/adapter/UserCommandAdapter.java
@@ -1,6 +1,8 @@
 package com.todaysfail.domains.user.adapter;
 
 import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.common.type.user.AccountRole;
+import com.todaysfail.common.type.user.AccountStatus;
 import com.todaysfail.common.type.user.OauthProvider;
 import com.todaysfail.domains.user.entity.UserEntity;
 import com.todaysfail.domains.user.port.UserCommandPort;
@@ -15,8 +17,14 @@ public class UserCommandAdapter implements UserCommandPort {
     private final UserRepository userRepository;
 
     @Override
-    public UserEntity registerUser(String name, OauthProvider provider, String oid) {
-        UserEntity userEntity = UserEntity.registerUser(name, provider, oid);
+    public UserEntity registerUser(
+            String name,
+            OauthProvider provider,
+            String oid,
+            AccountStatus accountStatus,
+            AccountRole accountRole) {
+        UserEntity userEntity =
+                UserEntity.registerUser(name, provider, oid, accountStatus, accountRole);
         return userRepository.save(userEntity);
     }
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/entity/UserEntity.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/entity/UserEntity.java
@@ -48,7 +48,12 @@ public class UserEntity extends BaseTimeEntity {
         this.accountRole = accountRole;
     }
 
-    public static UserEntity registerUser(String name, OauthProvider provider, String oid) {
-        return new UserEntity(name, provider, oid, AccountStatus.NORMAL, AccountRole.USER);
+    public static UserEntity registerUser(
+            String name,
+            OauthProvider provider,
+            String oid,
+            AccountStatus accountStatus,
+            AccountRole accountRole) {
+        return new UserEntity(name, provider, oid, accountStatus, accountRole);
     }
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/port/UserCommandPort.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/port/UserCommandPort.java
@@ -1,8 +1,15 @@
 package com.todaysfail.domains.user.port;
 
+import com.todaysfail.common.type.user.AccountRole;
+import com.todaysfail.common.type.user.AccountStatus;
 import com.todaysfail.common.type.user.OauthProvider;
 import com.todaysfail.domains.user.entity.UserEntity;
 
 public interface UserCommandPort {
-    UserEntity registerUser(String name, OauthProvider provider, String oid);
+    UserEntity registerUser(
+            String name,
+            OauthProvider provider,
+            String oid,
+            AccountStatus accountStatus,
+            AccountRole accountRole);
 }


### PR DESCRIPTION
### 연관 이슈
- close #30 
### 작업내용
- Events 객체 생성자 PRIVATE으로 방어
![image](https://github.com/TodaysFail/TodaysFail-Backend/assets/64088250/89556b70-75be-40d2-ac4b-8ad1b6055c8b)

- UserDomain 임시 변수 제거 이슈
- UserRegisterEvent 도메인 내부로 이동
- UserEntity에서 AccountStatus, AccountRole 설정해주던 부분을 도메인으로 이동
![image](https://github.com/TodaysFail/TodaysFail-Backend/assets/64088250/b69c39a3-12cc-4450-959c-0221971bdebd)
