### PR TITLE
[#25] feat: kakao oauth 관련 요청 feign 설정

### DIFF
--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/GlobalErrorCode.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/GlobalErrorCode.java
@@ -34,6 +34,14 @@ public enum GlobalErrorCode implements BaseErrorCode {
 
     SERVER_UNAVAILABLE(
             SERVICE_UNAVAILABLE, "GLOBAL_503_1", "현재 유지보수 및 과부하로 서버를 이용할 수 없습니다. 잠시 후 다시 시도해주세요"),
+
+    OTHER_SERVER_BAD_REQUEST(BAD_REQUEST, "FEIGN_400_1", "Other server bad request"),
+    OTHER_SERVER_UNAUTHORIZED(BAD_REQUEST, "FEIGN_400_2", "Other server unauthorized"),
+    OTHER_SERVER_FORBIDDEN(BAD_REQUEST, "FEIGN_400_3", "Other server forbidden"),
+    OTHER_SERVER_EXPIRED_TOKEN(BAD_REQUEST, "FEIGN_400_4", "Other server expired token"),
+    OTHER_SERVER_NOT_FOUND(BAD_REQUEST, "FEIGN_400_5", "Other server not found error"),
+    OTHER_SERVER_INTERNAL_SERVER_ERROR(
+            BAD_REQUEST, "FEIGN_400_6", "Other server internal server error"),
     ;
 
     private Integer status;

--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerBadRequestException.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerBadRequestException.java
@@ -1,0 +1,9 @@
+package com.todaysfail.common.exception;
+
+public class OtherServerBadRequestException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new OtherServerBadRequestException();
+
+    private OtherServerBadRequestException() {
+        super(GlobalErrorCode.OTHER_SERVER_BAD_REQUEST);
+    }
+}

--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerExpiredTokenException.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerExpiredTokenException.java
@@ -1,0 +1,9 @@
+package com.todaysfail.common.exception;
+
+public class OtherServerExpiredTokenException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new OtherServerExpiredTokenException();
+
+    private OtherServerExpiredTokenException() {
+        super(GlobalErrorCode.OTHER_SERVER_EXPIRED_TOKEN);
+    }
+}

--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerForbiddenException.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerForbiddenException.java
@@ -1,0 +1,9 @@
+package com.todaysfail.common.exception;
+
+public class OtherServerForbiddenException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new OtherServerForbiddenException();
+
+    private OtherServerForbiddenException() {
+        super(GlobalErrorCode.OTHER_SERVER_FORBIDDEN);
+    }
+}

--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerUnauthorizedException.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/OtherServerUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.todaysfail.common.exception;
+
+public class OtherServerUnauthorizedException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new OtherServerUnauthorizedException();
+
+    private OtherServerUnauthorizedException() {
+        super(GlobalErrorCode.OTHER_SERVER_UNAUTHORIZED);
+    }
+}

--- a/TodaysFail-Domain/src/test/java/com/todaysfail/DomainIntegrateSpringBootTest.java
+++ b/TodaysFail-Domain/src/test/java/com/todaysfail/DomainIntegrateSpringBootTest.java
@@ -6,9 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest(classes = DomainIntegrateTestConfig.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = DomainIntegrateTestConfig.class)
+@ActiveProfiles(resolver = DomainIntegrateProfileResolver.class)
 @Documented
 public @interface DomainIntegrateSpringBootTest {}

--- a/TodaysFail-Infrastructure/build.gradle
+++ b/TodaysFail-Infrastructure/build.gradle
@@ -8,4 +8,10 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     api 'org.springframework.boot:spring-boot-starter-data-redis'
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation ("io.github.openfeign:feign-httpclient:12.1")
+    implementation ("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
+    implementation ("io.github.openfeign:feign-jackson:12.1")
+    testImplementation ("org.springframework.cloud:spring-cloud-starter-contract-stub-runner:3.1.5")
+    testImplementation ("org.springframework.cloud:spring-cloud-contract-wiremock:3.1.5")
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/JpaConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/JpaConfig.java
@@ -1,8 +1,0 @@
-package com.todaysfail.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaConfig {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/feign/FeignClientErrorDecoder.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/feign/FeignClientErrorDecoder.java
@@ -1,0 +1,30 @@
+package com.todaysfail.config.feign;
+
+import com.todaysfail.common.exception.OtherServerBadRequestException;
+import com.todaysfail.common.exception.OtherServerExpiredTokenException;
+import com.todaysfail.common.exception.OtherServerForbiddenException;
+import com.todaysfail.common.exception.OtherServerUnauthorizedException;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class FeignClientErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        if (response.status() >= 400) {
+            switch (response.status()) {
+                case 401:
+                    throw OtherServerUnauthorizedException.EXCEPTION;
+                case 403:
+                    throw OtherServerForbiddenException.EXCEPTION;
+                case 419:
+                    throw OtherServerExpiredTokenException.EXCEPTION;
+                default:
+                    throw OtherServerBadRequestException.EXCEPTION;
+            }
+        }
+
+        return FeignException.errorStatus(methodKey, response);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/feign/FeignCommonConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/feign/FeignCommonConfig.java
@@ -1,0 +1,20 @@
+package com.todaysfail.config.feign;
+
+import static feign.Logger.*;
+
+import com.todaysfail.outer.api.BaseFeignClientPackage;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(FeignClientErrorDecoder.class)
+@EnableFeignClients(basePackageClasses = BaseFeignClientPackage.class)
+public class FeignCommonConfig {
+
+    @Bean
+    Level feignLoggerLevel() {
+        return Level.FULL;
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/OauthProperties.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/OauthProperties.java
@@ -1,15 +1,51 @@
 package com.todaysfail.config.properties;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
+@Getter
+@AllArgsConstructor
 @ConfigurationProperties(prefix = "oauth")
 @ConstructorBinding
-public record OauthProperties(OAuthSecret kakao) {
-    record OAuthSecret(
-            String baseUrl,
-            String clientId,
-            String clientSecret,
-            String redirectUrl,
-            String appId) {}
+public class OauthProperties {
+
+    private OAuthSecret kakao;
+
+    @Getter
+    @Setter
+    public static class OAuthSecret {
+        private String baseUrl;
+        private String clientId;
+        private String clientSecret;
+        private String redirectUrl;
+        private String appId;
+        private String adminKey;
+    }
+
+    public String getKakaoBaseUrl() {
+        return kakao.getBaseUrl();
+    }
+
+    public String getKakaoClientId() {
+        return kakao.getClientId();
+    }
+
+    public String getKakaoRedirectUrl() {
+        return kakao.getRedirectUrl();
+    }
+
+    public String getKakaoClientSecret() {
+        return kakao.getClientSecret();
+    }
+
+    public String getKakaoAppId() {
+        return kakao.getAppId();
+    }
+
+    public String getKakaoAdminKey() {
+        return kakao.getAdminKey();
+    }
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/example/entity/ExampleEntity.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/example/entity/ExampleEntity.java
@@ -6,14 +6,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity(name = "tbl_example")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExampleEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/BaseFeignClientPackage.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/BaseFeignClientPackage.java
@@ -1,0 +1,3 @@
+package com.todaysfail.outer.api;
+
+public interface BaseFeignClientPackage {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClient.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClient.java
@@ -1,0 +1,12 @@
+package com.todaysfail.outer.api.oauth.client;
+
+import com.todaysfail.outer.api.oauth.dto.KakaoInformationResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "KakaoInfoClient", url = "${feign.kakao.info}")
+public interface KakaoInfoClient {
+    @GetMapping("/v2/user/me")
+    KakaoInformationResponse kakaoUserInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClient.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClient.java
@@ -1,0 +1,23 @@
+package com.todaysfail.outer.api.oauth.client;
+
+import com.todaysfail.outer.api.oauth.dto.KakaoTokenResponse;
+import com.todaysfail.outer.api.oauth.dto.OIDCPublicKeysResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "KakaoOAuthClient", url = "${feign.kakao.oauth}")
+public interface KakaoOauthClient {
+    @PostMapping(
+            "/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
+    KakaoTokenResponse kakaoAuth(
+            @PathVariable("CLIENT_ID") String clientId,
+            @PathVariable("REDIRECT_URI") String redirectUri,
+            @PathVariable("CODE") String code,
+            @PathVariable("CLIENT_SECRET") String client_secret);
+
+    // TODO: 캐싱 적용
+    @GetMapping("/.well-known/jwks.json")
+    OIDCPublicKeysResponse kakaoOIDCOpenKeys();
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/KakaoInformationResponse.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/KakaoInformationResponse.java
@@ -1,0 +1,54 @@
+package com.todaysfail.outer.api.oauth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class KakaoInformationResponse {
+    private String id;
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonNaming(SnakeCaseStrategy.class)
+    public static class KakaoAccount {
+        private Profile profile;
+        private String name;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonNaming(SnakeCaseStrategy.class)
+        public static class Profile {
+            private String profileImageUrl;
+            private Boolean isDefaultImage;
+        }
+
+        public String getProfileImageUrl() {
+            return profile.getProfileImageUrl();
+        }
+
+        public Boolean getIsDefaultImage() {
+            return profile.getIsDefaultImage();
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return kakaoAccount.getName();
+    }
+
+    public String getProfileUrl() {
+        return kakaoAccount.getProfileImageUrl();
+    }
+
+    public Boolean getIsDefaultImage() {
+        return kakaoAccount.getProfile().getIsDefaultImage();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/KakaoTokenResponse.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/KakaoTokenResponse.java
@@ -1,0 +1,15 @@
+package com.todaysfail.outer.api.oauth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoTokenResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String idToken;
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/OIDCPublicKeyDto.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/OIDCPublicKeyDto.java
@@ -1,0 +1,3 @@
+package com.todaysfail.outer.api.oauth.dto;
+
+public record OIDCPublicKeyDto(String kid, String alg, String use, String n, String e) {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/OIDCPublicKeysResponse.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/OIDCPublicKeysResponse.java
@@ -1,0 +1,11 @@
+package com.todaysfail.outer.api.oauth.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OIDCPublicKeysResponse {
+    private List<OIDCPublicKeyDto> keys;
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/exception/KakaoOauthErrorCode.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/exception/KakaoOauthErrorCode.java
@@ -1,0 +1,51 @@
+package com.todaysfail.outer.api.oauth.exception;
+
+import static com.todaysfail.common.consts.TodaysFailConst.*;
+
+import com.todaysfail.common.dto.ErrorReason;
+import com.todaysfail.common.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum KakaoOauthErrorCode implements BaseErrorCode {
+    KOE101(BAD_REQUEST, "KAKAO_KOE101", "invalid_client", "잘못된 앱 키 타입을 사용하거나 앱 키에 오타가 있을 경우"),
+    KOE009(BAD_REQUEST, "KAKAO_KOE009", "misconfigured", "등록되지 않은 플랫폼에서 액세스 토큰을 요청 하는 경우"),
+    KOE010(
+            BAD_REQUEST,
+            "KAKAO_KOE101",
+            "invalid_client",
+            "클라이언트 시크릿(Client secret) 기능을 사용하는 앱에서 토큰 요청 시 client_secret 값을 전달하지 않거나 정확하지 않은 값을 전달하는 경우"),
+    KOE303(
+            BAD_REQUEST,
+            "KAKAO_KOE303",
+            "invalid_grant",
+            "인가 코드 요청 시 사용한 redirect_uri와 액세스 토큰 요청 시 사용한 redirect_uri가 다른 경우"),
+    KOE319(BAD_REQUEST, "KAKAO_KOE319", "invalid_grant", "토큰 갱신 요청 시 리프레시 토큰을 전달하지 않는 경우"),
+    KOE320(
+            BAD_REQUEST,
+            "KAKAO_KOE320",
+            "invalid_grant",
+            "동일한 인가 코드를 두 번 이상 사용하거나, 이미 만료된 인가 코드를 사용한 경우, 혹은 인가 코드를 찾을 수 없는 경우"),
+    KOE322(
+            BAD_REQUEST,
+            "KAKAO_KOE322",
+            "invalid_grant",
+            "refresh_token을 찾을 수 없거나 이미 만료된 리프레시 토큰을 사용한 경우"),
+    KOE_INVALID_REQUEST(BAD_REQUEST, "KAKAO_KOE_INVALID_REQUEST", "invalid_request", "잘못된 요청인 경우"),
+    KOE400(BAD_REQUEST, "KAKAO_KOE400", "invalid_token", "ID 토큰 값이 전달되지 않았거나 올바른 형식이 아닌 ID 토큰인 경우"),
+    KOE401(BAD_REQUEST, "KAKAO_KOE401", "invalid_token", "ID 토큰을 발급한 인증 기관(iss)이 카카오 인증 서버"),
+    KOE402(BAD_REQUEST, "KAKAO_KOE402", "invalid_token", "서명이 올바르지 않아 유효한 ID 토큰이 아닌 경우"),
+    KOE403(BAD_REQUEST, "KAKAO_KOE403", "invalid_token", "만료된 ID 토큰인 경우");
+
+    private Integer status;
+    private String errorCode;
+    private String error;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().status(status).code(errorCode).reason(reason).build();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/TodaysFail-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -3,6 +3,18 @@ spring:
     host: ${REDIS_HOST:localhost}
     port: ${REDIS_PORT:6379}
     password: ${REDIS_PASSWORD:}
+oauth:
+  kakao:
+    base-url: ${KAKAO_BASE_URL}
+    client-id: ${KAKAO_CLIENT}
+    client-secret: ${KAKAO_SECRET}
+    redirect-url: ${KAKAO_REDIRECT}
+    app-id: ${KAKAO_APP_ID:default}
+    admin-key: ${KAKAO_ADMIN_KEY}
+feign:
+  kakao:
+    info : https://kapi.kakao.com
+    oauth : https://kauth.kakao.com
 ---
 spring:
   config:

--- a/TodaysFail-Infrastructure/src/test/java/com/todaysfail/InfraIntegrateProfileResolver.java
+++ b/TodaysFail-Infrastructure/src/test/java/com/todaysfail/InfraIntegrateProfileResolver.java
@@ -5,6 +5,6 @@ import org.springframework.test.context.ActiveProfilesResolver;
 public class InfraIntegrateProfileResolver implements ActiveProfilesResolver {
     @Override
     public String[] resolve(Class<?> testClass) {
-        return new String[] {"test, infrastructure"};
+        return new String[] {"test", "infrastructure"};
     }
 }

--- a/TodaysFail-Infrastructure/src/test/java/com/todaysfail/InfraIntegrateSpringBootTest.java
+++ b/TodaysFail-Infrastructure/src/test/java/com/todaysfail/InfraIntegrateSpringBootTest.java
@@ -6,9 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest(classes = InfraIntegrateTestConfig.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = InfraIntegrateTestConfig.class)
+@ActiveProfiles(resolver = InfraIntegrateProfileResolver.class)
 @Documented
 public @interface InfraIntegrateSpringBootTest {}

--- a/TodaysFail-Infrastructure/src/test/java/com/todaysfail/config/properties/OauthPropertiesTest.java
+++ b/TodaysFail-Infrastructure/src/test/java/com/todaysfail/config/properties/OauthPropertiesTest.java
@@ -1,0 +1,18 @@
+package com.todaysfail.config.properties;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.todaysfail.InfraIntegrateSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@InfraIntegrateSpringBootTest
+class OauthPropertiesTest {
+    @Autowired private OauthProperties oauthProperties;
+
+    @Test
+    void oauth_프로퍼티가_정상적으로_init_되어야한다() {
+        assertEquals(oauthProperties.getKakao().getAppId(), "default");
+    }
+}

--- a/TodaysFail-Infrastructure/src/test/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClientTest.java
+++ b/TodaysFail-Infrastructure/src/test/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClientTest.java
@@ -49,7 +49,7 @@ class KakaoInfoClientTest {
         var response = kakaoInfoClient.kakaoUserInfo("accessToken");
 
         // then
-        assertEquals(response.getKakaoAccount().getName(), "sample@sample.com");
+        assertEquals(response.getKakaoAccount().getName(), "홍길동");
         assertEquals(
                 response.getKakaoAccount().getProfileImageUrl(),
                 "http://yyy.kakao.com/dn/.../img_640x640.jpg");

--- a/TodaysFail-Infrastructure/src/test/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClientTest.java
+++ b/TodaysFail-Infrastructure/src/test/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClientTest.java
@@ -1,0 +1,58 @@
+package com.todaysfail.outer.api.oauth.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.todaysfail.InfraIntegrateProfileResolver;
+import com.todaysfail.InfraIntegrateTestConfig;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.spec.internal.HttpStatus;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.ResourceUtils;
+
+@ContextConfiguration
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = InfraIntegrateTestConfig.class)
+@AutoConfigureWireMock(port = 0)
+@ActiveProfiles(resolver = InfraIntegrateProfileResolver.class)
+@TestPropertySource(properties = "feign.kakao.info=http://localhost:${wiremock.server.port}")
+class KakaoInfoClientTest {
+    @Autowired KakaoInfoClient kakaoInfoClient;
+
+    @Test
+    @DisplayName("카카오 유저 정보 요청이 올바르게 파싱되어야한다")
+    void 카카오_유저_정보_요청이_올바르게_파싱되어야한다() throws IOException {
+        // given
+        Path filePath =
+                ResourceUtils.getFile("classpath:payload/oauth-user-info-response.json").toPath();
+        WireMock.stubFor(
+                WireMock.get(WireMock.urlPathEqualTo("/v2/user/me"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(HttpStatus.OK)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(Files.readAllBytes(filePath))));
+
+        // when
+        var response = kakaoInfoClient.kakaoUserInfo("accessToken");
+
+        // then
+        assertEquals(response.getKakaoAccount().getName(), "sample@sample.com");
+        assertEquals(
+                response.getKakaoAccount().getProfileImageUrl(),
+                "http://yyy.kakao.com/dn/.../img_640x640.jpg");
+        assertEquals(response.getKakaoAccount().getIsDefaultImage(), false);
+    }
+}

--- a/TodaysFail-Infrastructure/src/test/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClientTest.java
+++ b/TodaysFail-Infrastructure/src/test/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClientTest.java
@@ -1,0 +1,74 @@
+package com.todaysfail.outer.api.oauth.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.todaysfail.InfraIntegrateProfileResolver;
+import com.todaysfail.InfraIntegrateTestConfig;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.spec.internal.HttpStatus;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.ResourceUtils;
+
+@ContextConfiguration
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = InfraIntegrateTestConfig.class)
+@AutoConfigureWireMock(port = 0)
+@ActiveProfiles(resolver = InfraIntegrateProfileResolver.class)
+@TestPropertySource(properties = "feign.kakao.oauth=http://localhost:${wiremock.server.port}")
+class KakaoOauthClientTest {
+    @Autowired KakaoOauthClient kakaoOauthClient;
+
+    @Test
+    @DisplayName("카카오 OAuth 토큰 요청이 올바르게 파싱되어야한다")
+    void 카카오_OAuth_토큰_요청이_올바르게_파싱되어야한다() throws IOException {
+        // given
+        Path filePath =
+                ResourceUtils.getFile("classpath:payload/oauth-token-response.json").toPath();
+        WireMock.stubFor(
+                WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(HttpStatus.OK)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(Files.readAllBytes(filePath))));
+
+        // when
+        var response =
+                kakaoOauthClient.kakaoAuth("CLIENT_ID", "REDIRECT_URI", "CODE", "CLIENT_SECRET");
+        assertEquals(response.getIdToken(), "idToken");
+        assertEquals(response.getAccessToken(), "accessToken");
+        assertEquals(response.getRefreshToken(), "refreshToken");
+    }
+
+    @Test
+    @DisplayName("카카오 OIDC 공개키 요청이 올바르게 파싱되어야한다")
+    void 카카오_OIDC_공개키_요청이_올바르게_파싱되어야한다() throws IOException {
+        var file =
+                ResourceUtils.getFile("classpath:payload/oauth-oidc-public-key-response.json")
+                        .toPath();
+        WireMock.stubFor(
+                WireMock.get(WireMock.urlPathEqualTo("/.well-known/jwks.json"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(HttpStatus.OK)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(Files.readAllBytes(file))));
+        var response = kakaoOauthClient.kakaoOIDCOpenKeys();
+        assertEquals(response.getKeys().get(0).kid(), "kid1");
+        assertEquals(response.getKeys().get(1).kid(), "kid2");
+    }
+}

--- a/TodaysFail-Infrastructure/src/test/resources/payload/oauth-oidc-public-key-response.json
+++ b/TodaysFail-Infrastructure/src/test/resources/payload/oauth-oidc-public-key-response.json
@@ -1,0 +1,19 @@
+{
+  "keys": [
+    {
+      "kid": "kid1",
+      "kty": "RSA",
+      "alg": "RS256",
+      "use": "sig",
+      "n" : "n1",
+      "e": "e1"
+    }, {
+      "kid": "kid2",
+      "kty": "RSA",
+      "alg": "RS256",
+      "use": "sig",
+      "n" : "n2",
+      "e": "e2"
+    }
+  ]
+}

--- a/TodaysFail-Infrastructure/src/test/resources/payload/oauth-token-response.json
+++ b/TodaysFail-Infrastructure/src/test/resources/payload/oauth-token-response.json
@@ -1,0 +1,9 @@
+{
+  "token_type": "bearer",
+  "access_token": "accessToken",
+  "id_token": "idToken",
+  "expires_in": 1000,
+  "refresh_token": "refreshToken",
+  "refresh_token_expires_in": 1000,
+  "scope": "profile_image openid profile_nickname"
+}

--- a/TodaysFail-Infrastructure/src/test/resources/payload/oauth-user-info-response.json
+++ b/TodaysFail-Infrastructure/src/test/resources/payload/oauth-user-info-response.json
@@ -1,0 +1,34 @@
+{
+  "id":123456789,
+  "connected_at": "2023-07-08T07:45:28Z",
+  "kakao_account": {
+    "profile_nickname_needs_agreement": false,
+    "profile_image_needs_agreement": false,
+    "profile": {
+      "nickname": "홍길동",
+      "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
+      "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+      "is_default_image":false
+    },
+    "name_needs_agreement":false,
+    "name":"홍길동",
+    "email_needs_agreement":false,
+    "is_email_valid": true,
+    "is_email_verified": true,
+    "email": "sample@sample.com",
+    "age_range_needs_agreement":false,
+    "age_range":"20~29",
+    "birthyear_needs_agreement": false,
+    "birthyear": "2002",
+    "birthday_needs_agreement":false,
+    "birthday":"1130",
+    "birthday_type":"SOLAR",
+    "gender_needs_agreement":false,
+    "gender":"female",
+    "phone_number_needs_agreement": false,
+    "phone_number": "+82 010-1234-5678",
+    "ci_needs_agreement": false,
+    "ci": "${CI}",
+    "ci_authenticated_at": "2019-03-11T11:25:22Z"
+  }
+}

--- a/TodaysFail-Interface/src/test/java/com/todaysfail/InterfaceIntegrateSpringBootTest.java
+++ b/TodaysFail-Interface/src/test/java/com/todaysfail/InterfaceIntegrateSpringBootTest.java
@@ -6,9 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest(classes = InterfaceIntegrateTestConfig.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = InterfaceIntegrateTestConfig.class)
+@ActiveProfiles(resolver = InterfaceIntegrateProfileResolver.class)
 @Documented
 public @interface InterfaceIntegrateSpringBootTest {}


### PR DESCRIPTION
### 연관 이슈
- close #25
### 작업내용
- 카카오 oauth시 필요한 클라이언트 feign으로 설정
- oauth api (oauth 토큰요청, oidc 공개키 요청, 유저 정보 조회) 생성
- wiremock을 도입하여 파싱되는지 테스트
 [[스프링] spring feign client wiremock test](https://devnm.tistory.com/34)