### PR TITLE
[#33] feat: 레디스 캐시 처리용 설정 및 적용

### DIFF
--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/redis/RedisCacheConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/redis/RedisCacheConfig.java
@@ -1,0 +1,35 @@
+package com.todaysfail.config.redis;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager oidcCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()))
+                        .entryTtl(Duration.ofDays(7L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/redis/RedisConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/redis/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.todaysfail.config.redis;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories(
+        basePackages = "com.todaysfail",
+        enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig =
+                new RedisStandaloneConfiguration(redisHost, redisPort);
+        if (!redisPassword.isBlank()) redisConfig.setPassword(redisPassword);
+        LettuceClientConfiguration clientConfig =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(1))
+                        .shutdownTimeout(Duration.ZERO)
+                        .build();
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClient.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClient.java
@@ -2,6 +2,7 @@ package com.todaysfail.outer.api.oauth.client;
 
 import com.todaysfail.outer.api.oauth.dto.KakaoTokenResponse;
 import com.todaysfail.outer.api.oauth.dto.OIDCPublicKeysResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,7 +18,7 @@ public interface KakaoOauthClient {
             @PathVariable("CODE") String code,
             @PathVariable("CLIENT_SECRET") String client_secret);
 
-    // TODO: 캐싱 적용
     @GetMapping("/.well-known/jwks.json")
+    @Cacheable(cacheNames = "KakaoOIDC", cacheManager = "oidcCacheManager")
     OIDCPublicKeysResponse kakaoOIDCOpenKeys();
 }


### PR DESCRIPTION
### 연관 이슈
- close #33
### 작업내용
- Redis를 사용하기위한 Redis Config 생성
- Redis를 Cache용도로 사용하기 위한 CacheManager 생성 (OIDC 용)
- OIDC 공개키 요청 API에 캐시 적용