### PR TITLE
[#52] cicd: dev 환경 배포내역 버전대신 커밋 해시값 사용

### DIFF
--- a/.github/workflows/develop_cd.yml
+++ b/.github/workflows/develop_cd.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'version'
+        description: 'commit_hash'
         required: true
 jobs:
   cd:
@@ -42,7 +42,7 @@ jobs:
           script: |
             aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ECR_REGISTRY_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
             cd ~/TodaysFail-Backend
-            VERSION=${{ github.event.inputs.version }}
+            VERSION=${{ github.event.inputs.commit_hash }}
             sed -i "s/VERSION=.*/VERSION=$VERSION/" .env
             docker-compose -f ~/TodaysFail-Backend/docker-compose-develop.yml pull
             docker-compose -f ~/TodaysFail-Backend/docker-compose-develop.yml up --build -d
@@ -62,6 +62,9 @@ jobs:
 
             *배포 버전*
             ${{ github.event.inputs.version }}
+            
+            *배포 내역 보기*
+            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.version }}
 
       - name: Notify on failure
         if: ${{ failure() }}
@@ -77,3 +80,6 @@ jobs:
 
             *배포 버전*
             ${{ github.event.inputs.version }}
+            
+            *배포 내역 보기*
+            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.version }}

--- a/.github/workflows/develop_cd.yml
+++ b/.github/workflows/develop_cd.yml
@@ -64,7 +64,7 @@ jobs:
             ${{ github.event.inputs.version }}
             
             *배포 내역 보기*
-            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.version }}
+            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.commit_hash }}
 
       - name: Notify on failure
         if: ${{ failure() }}
@@ -82,4 +82,4 @@ jobs:
             ${{ github.event.inputs.version }}
             
             *배포 내역 보기*
-            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.version }}
+            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.commit_hash }}

--- a/.github/workflows/develop_cicd.yml
+++ b/.github/workflows/develop_cicd.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: get project version
         id: get_version
-        run: echo "::set-output name=VERSION::$(./gradlew projectVersion -q)"
+        run: echo "::set-output name=VERSION::${{ github.sha }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -120,6 +120,9 @@ jobs:
             
             *배포 내역*
             ${{ join(github.event.commits.*.message, '\n') }}
+            
+            *배포 내역 보기*
+            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ needs.ci.outputs.VERSION }}
 
       - name: Notify on failure
         if: ${{ failure() }}
@@ -138,3 +141,6 @@ jobs:
             
             *배포 내역*
             ${{ join(github.event.commits.*.message, '\n') }}
+            
+            *배포 내역 보기*
+            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ needs.ci.outputs.VERSION }}


### PR DESCRIPTION
### 연관 이슈
- close #52 
### 작업내용
- dev 환경에서는 project의 version 값 보다 git sha 버전을 사용하는게 더 낫다고 판단
- 추 후 prod 환경에서는 기존과 같이 project의 version 사용 예정