### PR TITLE
[#59] feat: GlobalExceptionHandling

### DIFF
--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/dto/ErrorResponse.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/dto/ErrorResponse.java
@@ -1,0 +1,32 @@
+package com.todaysfail.common.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private final boolean success = false;
+    private final int status;
+    private final String code;
+    private final String reason;
+    private final LocalDateTime timeStamp;
+
+    private final String path;
+
+    public ErrorResponse(ErrorReason errorReason, String path) {
+        this.status = errorReason.getStatus();
+        this.code = errorReason.getCode();
+        this.reason = errorReason.getReason();
+        this.timeStamp = LocalDateTime.now();
+        this.path = path;
+    }
+
+    public ErrorResponse(int status, String code, String reason, String path) {
+        this.status = status;
+        this.code = code;
+        this.reason = reason;
+        this.timeStamp = LocalDateTime.now();
+        this.path = path;
+    }
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/config/response/GlobalExceptionHandler.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/config/response/GlobalExceptionHandler.java
@@ -1,0 +1,147 @@
+package com.todaysfail.config.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todaysfail.common.dto.ErrorReason;
+import com.todaysfail.common.dto.ErrorResponse;
+import com.todaysfail.common.exception.BaseErrorCode;
+import com.todaysfail.common.exception.GlobalErrorCode;
+import com.todaysfail.common.exception.TodaysFailCodeException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex, Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        String url =
+                UriComponentsBuilder.fromHttpRequest(
+                                new ServletServerHttpRequest(servletWebRequest.getRequest()))
+                        .build()
+                        .toUriString();
+
+        ErrorResponse errorResponse =
+                new ErrorResponse(status.value(), status.name(), ex.getMessage(), url);
+        return super.handleExceptionInternal(ex, errorResponse, headers, status, request);
+    }
+
+    /** Validation 예외 처리 */
+    @Override
+    @SneakyThrows
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+
+        List<FieldError> errors = ex.getBindingResult().getFieldErrors();
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        String url =
+                UriComponentsBuilder.fromHttpRequest(
+                                new ServletServerHttpRequest(servletWebRequest.getRequest()))
+                        .build()
+                        .toUriString();
+        Map<String, Object> fieldAndErrorMessages =
+                errors.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        FieldError::getField, FieldError::getDefaultMessage));
+
+        String errorsToJsonString = new ObjectMapper().writeValueAsString(fieldAndErrorMessages);
+        ErrorResponse errorResponse =
+                new ErrorResponse(status.value(), status.name(), errorsToJsonString, url);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /** Request Param Validation 예외 처리 */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> ConstraintViolationExceptionHandler(
+            ConstraintViolationException e, HttpServletRequest request) {
+        Map<String, Object> bindingErrors = new HashMap<>();
+        e.getConstraintViolations()
+                .forEach(
+                        constraintViolation -> {
+                            List<String> propertyPath =
+                                    List.of(
+                                            constraintViolation
+                                                    .getPropertyPath()
+                                                    .toString()
+                                                    .split("\\."));
+                            String path =
+                                    propertyPath.stream()
+                                            .skip(propertyPath.size() - 1L)
+                                            .findFirst()
+                                            .orElse(null);
+                            bindingErrors.put(path, constraintViolation.getMessage());
+                        });
+
+        ErrorReason errorReason =
+                ErrorReason.builder()
+                        .code("BAD_REQUEST")
+                        .status(400)
+                        .reason(bindingErrors.toString())
+                        .build();
+        ErrorResponse errorResponse =
+                new ErrorResponse(errorReason, request.getRequestURL().toString());
+        return ResponseEntity.status(HttpStatus.valueOf(errorReason.getStatus()))
+                .body(errorResponse);
+    }
+
+    /** TodaysFailCodeException 예외 처리 */
+    @ExceptionHandler(TodaysFailCodeException.class)
+    public ResponseEntity<ErrorResponse> TodaysFailCodeExceptionHandler(
+            TodaysFailCodeException e, HttpServletRequest request) {
+        BaseErrorCode code = e.getErrorCode();
+        ErrorReason errorReason = code.getErrorReason();
+        ErrorResponse errorResponse =
+                new ErrorResponse(errorReason, request.getRequestURL().toString());
+        return ResponseEntity.status(HttpStatus.valueOf(errorReason.getStatus()))
+                .body(errorResponse);
+    }
+
+    /** 500번대 에러 처리 */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(
+            Exception e, HttpServletRequest request) {
+        String url =
+                UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request))
+                        .build()
+                        .toUriString();
+
+        log.error("INTERNAL_SERVER_ERROR", e);
+        GlobalErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse errorResponse =
+                new ErrorResponse(
+                        internalServerError.getStatus(),
+                        internalServerError.getCode(),
+                        internalServerError.getReason(),
+                        url);
+
+        return ResponseEntity.status(HttpStatus.valueOf(internalServerError.getStatus()))
+                .body(errorResponse);
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #59 
### 작업내용
- ResponseEntityExceptionHandler클래스를 상속받아 handleExceptionInternal메서드로 ErrorResponse 형태로 공통된 형식으로 에러를 return하도록 설정
- Valid 어노테이션 사용하여 Validation 실패 시 발생하는 MethodArgumentNotValidException 핸들링
- Request Param Validation 실패 시 발생하는 ConstraintViolationException 핸들링
- TodaysFailCodeException 핸들링
- 500번대 에러 핸들링 (추 후 슬랙 메세지 발송 기능 추가 예정)