### PR TITLE
[#62] fix: InMemoryUserDetailsManager에 Swagger User Password 암호화

### DIFF
--- a/TodaysFail-Interface/src/main/java/com/todaysfail/config/security/SecurityConfig.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/config/security/SecurityConfig.java
@@ -32,12 +32,12 @@ public class SecurityConfig {
 
     @Bean
     public InMemoryUserDetailsManager inMemoryUserDetailsManager() {
-        UserDetails swaggerUser =
-                User.withUsername(this.swaggerUser)
-                        .password(swaggerPassword)
+        UserDetails user =
+                User.withUsername(swaggerUser)
+                        .password(passwordEncoder().encode(swaggerPassword))
                         .roles("SWAGGER")
                         .build();
-        return new InMemoryUserDetailsManager(swaggerUser);
+        return new InMemoryUserDetailsManager(user);
     }
 
     @Bean


### PR DESCRIPTION
### 연관 이슈
- close #62 
### 작업내용
- Swagger User의 Password를 암호화하지 않아 `Encoded password does not look like BCrypt` 발생
- UserDetails 생성 시 Password를 암호화 하여 적용