### PR TITLE
[#64] feat: 유저 탈퇴 기능 추가

### DIFF
--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/TodaysFailDynamicException.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/exception/TodaysFailDynamicException.java
@@ -1,0 +1,12 @@
+package com.todaysfail.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TodaysFailDynamicException extends RuntimeException {
+    private final int status;
+    private final String code;
+    private final String reason;
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/auth/helper/KakaoOauthHelper.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/auth/helper/KakaoOauthHelper.java
@@ -13,6 +13,7 @@ import com.todaysfail.outer.api.oauth.client.KakaoOauthClient;
 import com.todaysfail.outer.api.oauth.dto.KakaoInformationResponse;
 import com.todaysfail.outer.api.oauth.dto.KakaoTokenResponse;
 import com.todaysfail.outer.api.oauth.dto.OIDCPublicKeysResponse;
+import com.todaysfail.outer.api.oauth.dto.UnlinkKaKaoTarget;
 import lombok.RequiredArgsConstructor;
 
 @Helper
@@ -65,5 +66,12 @@ public class KakaoOauthHelper {
     public OauthInfo getOauthInfoByIdToken(String idToken) {
         OIDCDecodePayload oidcDecodePayload = getOIDCDecodePayload(idToken);
         return OauthInfo.of(oidcDecodePayload.getSub(), OauthProvider.KAKAO);
+    }
+
+    public void unlink(String oid) {
+        String kakaoAdminKey = oauthProperties.getKakaoAdminKey();
+        UnlinkKaKaoTarget unlinkKaKaoTarget = UnlinkKaKaoTarget.from(oid);
+        String header = "KakaoAK " + kakaoAdminKey;
+        kakaoInfoClient.unlinkUser(header, unlinkKaKaoTarget);
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/FcmNotification.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/FcmNotification.java
@@ -20,4 +20,10 @@ public class FcmNotification {
     public static FcmNotification updateToken(FcmNotification originalState, String fcmToken) {
         return new FcmNotification(fcmToken, originalState.pushAlarm, originalState.eventAlarm);
     }
+
+    public void withDraw() {
+        this.fcmToken = "";
+        this.pushAlarm = false;
+        this.eventAlarm = false;
+    }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/OauthInfo.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/OauthInfo.java
@@ -1,6 +1,9 @@
 package com.todaysfail.domains.user.domain;
 
+import static com.todaysfail.common.consts.TodaysFailConst.*;
+
 import com.todaysfail.common.type.user.OauthProvider;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,5 +18,10 @@ public class OauthInfo {
 
     public static OauthInfo of(String oauthId, OauthProvider provider) {
         return new OauthInfo(oauthId, provider);
+    }
+
+    public void withDraw() {
+        String withDrawOid = WITHDRAW_PREFIX + LocalDateTime.now() + ":" + oauthId;
+        this.oauthId = withDrawOid;
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/Profile.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/Profile.java
@@ -18,4 +18,10 @@ public class Profile {
     public static Profile from(String name, String profileImg, Boolean isDefaultImg) {
         return new Profile(name, profileImg, isDefaultImg);
     }
+
+    public void withDraw() {
+        this.name = "탈퇴한 사용자";
+        this.profileImg = "";
+        this.isDefaultImg = true;
+    }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/User.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/domain/User.java
@@ -4,6 +4,7 @@ import com.todaysfail.aop.event.Events;
 import com.todaysfail.common.type.user.UserRole;
 import com.todaysfail.common.type.user.UserStatus;
 import com.todaysfail.domains.user.entity.UserEntity;
+import com.todaysfail.domains.user.exception.AlreadyDeletedUserException;
 import com.todaysfail.domains.user.exception.UserForbiddenException;
 import com.todaysfail.events.UserRegisterEvent;
 import java.time.LocalDateTime;
@@ -92,5 +93,15 @@ public class User {
             throw UserForbiddenException.EXCEPTION;
         }
         lastLoginAt = LocalDateTime.now();
+    }
+
+    public void withDraw() {
+        if (userStatus == UserStatus.DELETED) {
+            throw AlreadyDeletedUserException.EXCEPTION;
+        }
+        userStatus = UserStatus.DELETED;
+        profile.withDraw();
+        fcmNotification.withDraw();
+        oauthInfo.withDraw();
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/exception/AlreadyDeletedUserException.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/exception/AlreadyDeletedUserException.java
@@ -1,0 +1,11 @@
+package com.todaysfail.domains.user.exception;
+
+import com.todaysfail.common.exception.TodaysFailCodeException;
+
+public class AlreadyDeletedUserException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new AlreadyDeletedUserException();
+
+    public AlreadyDeletedUserException() {
+        super(UserErrorCode.USER_ALREADY_DELETED);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/exception/UserErrorCode.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/exception/UserErrorCode.java
@@ -13,6 +13,7 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_ALREADY_SIGNUP(BAD_REQUEST, "USER_400_1", "이미 회원가입한 유저입니다."),
     USER_NOT_FOUND(NOT_FOUND, "USER_400_2", "유저 정보를 찾을 수 없습니다."),
     USER_FORBIDDEN(FORBIDDEN, "USER_403_1", "접근이 제한된 유저입니다"),
+    USER_ALREADY_DELETED(FORBIDDEN, "USER_403_2", "이미 삭제된 유저입니다."),
     NICKNAME_GENERATION_FAILED(CONFLICT, "USER_409_1", "닉네임 생성에 실패했습니다."),
     ALREADY_USER_NAME(CONFLICT, "USER_409_2", "이미 등록된 닉네임입니다."),
     ;

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserQueryService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserQueryService.java
@@ -5,13 +5,13 @@ import com.todaysfail.domains.user.domain.User;
 import com.todaysfail.domains.user.domain.UserDetail;
 import com.todaysfail.domains.user.entity.UserEntity;
 import com.todaysfail.domains.user.exception.UserNotFountException;
-import com.todaysfail.domains.user.usecase.QueryUserUseCase;
+import com.todaysfail.domains.user.usecase.UserQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class QueryUserService implements QueryUserUseCase {
+public class UserQueryService implements UserQueryUseCase {
     private final UserQueryAdapter userQueryAdapter;
 
     @Override

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserWithDrawService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserWithDrawService.java
@@ -1,0 +1,35 @@
+package com.todaysfail.domains.user.service;
+
+import com.todaysfail.domains.auth.helper.KakaoOauthHelper;
+import com.todaysfail.domains.user.domain.User;
+import com.todaysfail.domains.user.entity.UserEntity;
+import com.todaysfail.domains.user.exception.UserNotFountException;
+import com.todaysfail.domains.user.port.RefreshTokenPort;
+import com.todaysfail.domains.user.port.UserCommandPort;
+import com.todaysfail.domains.user.port.UserQueryPort;
+import com.todaysfail.domains.user.usecase.UserWithDrawUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserWithDrawService implements UserWithDrawUseCase {
+    private final UserCommandPort userCommandPort;
+    private final UserQueryPort userQueryPort;
+    private final RefreshTokenPort refreshTokenPort;
+    private final KakaoOauthHelper kakaoOauthHelper;
+
+    @Override
+    @Transactional
+    public void execute(Long userId) {
+        refreshTokenPort.deleteByUserId(userId);
+        UserEntity userEntity =
+                userQueryPort.queryUser(userId).orElseThrow(() -> UserNotFountException.EXCEPTION);
+        User user = User.from(userEntity);
+        String oauthId = user.getOauthInfo().getOauthId();
+        user.withDraw();
+        userCommandPort.save(user.toEntity());
+        kakaoOauthHelper.unlink(oauthId);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/usecase/UserQueryUseCase.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/usecase/UserQueryUseCase.java
@@ -2,6 +2,6 @@ package com.todaysfail.domains.user.usecase;
 
 import com.todaysfail.domains.user.domain.UserDetail;
 
-public interface QueryUserUseCase {
+public interface UserQueryUseCase {
     UserDetail queryMyInfo(Long userId);
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/usecase/UserWithDrawUseCase.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/usecase/UserWithDrawUseCase.java
@@ -1,0 +1,5 @@
+package com.todaysfail.domains.user.usecase;
+
+public interface UserWithDrawUseCase {
+    void execute(Long userId);
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/feign/FeignCommonConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/feign/FeignCommonConfig.java
@@ -6,10 +6,8 @@ import com.todaysfail.outer.api.BaseFeignClientPackage;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import(FeignClientErrorDecoder.class)
 @EnableFeignClients(basePackageClasses = BaseFeignClientPackage.class)
 public class FeignCommonConfig {
 

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/jpa/JpaConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/jpa/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.todaysfail.config.config;
+package com.todaysfail.config.jpa;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/entity/UserEntity.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/user/entity/UserEntity.java
@@ -61,6 +61,7 @@ public class UserEntity extends BaseTimeEntity {
             Boolean pushAlarm,
             Boolean eventAlarm,
             LocalDateTime lastLoginAt) {
+        this.id = id;
         this.name = name;
         this.profileImg = profileImg;
         this.isDefaultImg = isDefaultImg;

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClient.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoInfoClient.java
@@ -1,12 +1,23 @@
 package com.todaysfail.outer.api.oauth.client;
 
+import com.todaysfail.outer.api.oauth.config.KakaoInfoConfig;
 import com.todaysfail.outer.api.oauth.dto.KakaoInformationResponse;
+import com.todaysfail.outer.api.oauth.dto.UnlinkKaKaoTarget;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "KakaoInfoClient", url = "${feign.kakao.info}")
+@FeignClient(
+        name = "KakaoInfoClient",
+        url = "${feign.kakao.info}",
+        configuration = KakaoInfoConfig.class)
 public interface KakaoInfoClient {
     @GetMapping("/v2/user/me")
     KakaoInformationResponse kakaoUserInfo(@RequestHeader("Authorization") String accessToken);
+
+    @PostMapping(path = "/v1/user/unlink", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    void unlinkUser(
+            @RequestHeader("Authorization") String adminKey, UnlinkKaKaoTarget unlinkKaKaoTarget);
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClient.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/client/KakaoOauthClient.java
@@ -1,5 +1,6 @@
 package com.todaysfail.outer.api.oauth.client;
 
+import com.todaysfail.outer.api.oauth.config.KakaoOauthConfig;
 import com.todaysfail.outer.api.oauth.dto.KakaoTokenResponse;
 import com.todaysfail.outer.api.oauth.dto.OIDCPublicKeysResponse;
 import org.springframework.cache.annotation.Cacheable;
@@ -8,7 +9,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@FeignClient(name = "KakaoOAuthClient", url = "${feign.kakao.oauth}")
+@FeignClient(
+        name = "KakaoOAuthClient",
+        url = "${feign.kakao.oauth}",
+        configuration = KakaoOauthConfig.class)
 public interface KakaoOauthClient {
     @PostMapping(
             "/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/KakaoInfoConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/KakaoInfoConfig.java
@@ -1,0 +1,22 @@
+package com.todaysfail.outer.api.oauth.config;
+
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@Import(KakaoInfoErrorDecoder.class)
+public class KakaoInfoConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(value = ErrorDecoder.class)
+    public KakaoInfoErrorDecoder commonFeignErrorDecoder() {
+        return new KakaoInfoErrorDecoder();
+    }
+
+    @Bean
+    Encoder formEncoder() {
+        return new feign.form.FormEncoder();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/KakaoInfoErrorDecoder.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/KakaoInfoErrorDecoder.java
@@ -1,4 +1,4 @@
-package com.todaysfail.config.feign;
+package com.todaysfail.outer.api.oauth.config;
 
 import com.todaysfail.common.exception.OtherServerBadRequestException;
 import com.todaysfail.common.exception.OtherServerExpiredTokenException;
@@ -8,7 +8,7 @@ import feign.FeignException;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 
-public class FeignClientErrorDecoder implements ErrorDecoder {
+public class KakaoInfoErrorDecoder implements ErrorDecoder {
 
     @Override
     public Exception decode(String methodKey, Response response) {

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/KakaoOauthConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/KakaoOauthConfig.java
@@ -1,0 +1,21 @@
+package com.todaysfail.outer.api.oauth.config;
+
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@Import(OauthErrorDecoder.class)
+public class KakaoOauthConfig {
+    @Bean
+    @ConditionalOnMissingBean(value = ErrorDecoder.class)
+    public OauthErrorDecoder commonFeignErrorDecoder() {
+        return new OauthErrorDecoder();
+    }
+
+    @Bean
+    Encoder formEncoder() {
+        return new feign.form.FormEncoder();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/OauthErrorDecoder.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/config/OauthErrorDecoder.java
@@ -1,0 +1,26 @@
+package com.todaysfail.outer.api.oauth.config;
+
+import com.todaysfail.common.dto.ErrorReason;
+import com.todaysfail.common.exception.TodaysFailDynamicException;
+import com.todaysfail.outer.api.oauth.dto.KakaoOauthErrorResponse;
+import com.todaysfail.outer.api.oauth.exception.KakaoInvalidReqeustException;
+import com.todaysfail.outer.api.oauth.exception.KakaoOauthErrorCode;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class OauthErrorDecoder implements ErrorDecoder {
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        KakaoOauthErrorResponse body = KakaoOauthErrorResponse.from(response);
+
+        try {
+            KakaoOauthErrorCode kakaoOauthErrorCode =
+                    KakaoOauthErrorCode.valueOf(body.getErrorCode());
+            ErrorReason errorReason = kakaoOauthErrorCode.getErrorReason();
+            throw new TodaysFailDynamicException(
+                    errorReason.getStatus(), errorReason.getCode(), errorReason.getReason());
+        } catch (IllegalArgumentException e) {
+            throw KakaoInvalidReqeustException.EXCEPTION;
+        }
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/KakaoOauthErrorResponse.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/KakaoOauthErrorResponse.java
@@ -1,0 +1,34 @@
+package com.todaysfail.outer.api.oauth.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.todaysfail.common.exception.GlobalErrorCode;
+import com.todaysfail.common.exception.TodaysFailDynamicException;
+import feign.Response;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class KakaoOauthErrorResponse {
+    private String error;
+    private String errorCode;
+    private String errorDescription;
+
+    public static KakaoOauthErrorResponse from(Response response) {
+        try (InputStream bodyIs = response.body().asInputStream()) {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(bodyIs, KakaoOauthErrorResponse.class);
+        } catch (IOException e) {
+            GlobalErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+            throw new TodaysFailDynamicException(
+                    internalServerError.getStatus(),
+                    internalServerError.getCode(),
+                    internalServerError.getReason());
+        }
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/UnlinkKaKaoTarget.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/dto/UnlinkKaKaoTarget.java
@@ -1,0 +1,21 @@
+package com.todaysfail.outer.api.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UnlinkKaKaoTarget {
+
+    @feign.form.FormProperty("target_id_type")
+    private String targetIdType = "user_id";
+
+    @feign.form.FormProperty("target_id")
+    private String aud;
+
+    public UnlinkKaKaoTarget(String aud) {
+        this.aud = aud;
+    }
+
+    public static UnlinkKaKaoTarget from(String aud) {
+        return new UnlinkKaKaoTarget(aud);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/exception/KakaoInvalidReqeustException.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/outer/api/oauth/exception/KakaoInvalidReqeustException.java
@@ -1,0 +1,11 @@
+package com.todaysfail.outer.api.oauth.exception;
+
+import com.todaysfail.common.exception.TodaysFailCodeException;
+
+public class KakaoInvalidReqeustException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new KakaoInvalidReqeustException();
+
+    public KakaoInvalidReqeustException() {
+        super(KakaoOauthErrorCode.KOE_INVALID_REQUEST);
+    }
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/auth/AuthController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/auth/AuthController.java
@@ -45,13 +45,16 @@ public class AuthController {
         return authMapper.toTokenAndUserResponse(registerUserUseCase.upsertKakaoOauthUser(code));
     }
 
-    @Operation(summary = "kakao oauth 링크발급 ( 백엔드용 )", description = "kakao 링크를 받아볼수 있습니다.")
+    @Operation(
+            summary = "kakao oauth 링크발급 ( 백엔드용 )",
+            description = "kakao 링크를 받아볼수 있습니다.",
+            deprecated = true)
     @GetMapping("/oauth/kakao/link/test")
     public OauthLoginLinkResponse getKakaoOauthLink() {
         return authMapper.toOauthLoginLinkResponse(registerUserUseCase.getKaKaoOauthLink());
     }
 
-    @Operation(summary = "카카오 code 요청받는 곳입니다. ( 백엔드 용 ) ")
+    @Operation(summary = "카카오 code 요청받는 곳입니다. ( 백엔드용 )", deprecated = true)
     @GetMapping("/oauth/kakao")
     public OauthTokenResponse getCredentialFromKaKao(@RequestParam("code") String code) {
         return authMapper.toOauthTokenResponse(registerUserUseCase.getCredentialFromKaKao(code));
@@ -83,7 +86,7 @@ public class AuthController {
         return authMapper.toAbleRegisterResponse(registerUserUseCase.checkAvailableRegister(token));
     }
 
-    @Operation(summary = "accessToken 으로 oauth user 정보를 가져옵니다.")
+    @Operation(summary = "accessToken 으로 oauth user 정보를 가져옵니다.", deprecated = true)
     @PostMapping("/oauth/kakao/info")
     public OauthUserInfoResponse kakaoOauthUserInfo(
             @RequestParam("access_token") String accessToken) {

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/UserController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/UserController.java
@@ -4,12 +4,14 @@ import com.todaysfail.api.web.user.dto.response.RandomNicknameResponse;
 import com.todaysfail.api.web.user.mapper.UserMapper;
 import com.todaysfail.config.security.SecurityUtils;
 import com.todaysfail.domains.user.domain.UserDetail;
-import com.todaysfail.domains.user.usecase.QueryUserUseCase;
 import com.todaysfail.domains.user.usecase.RandomNicknameUseCase;
+import com.todaysfail.domains.user.usecase.UserQueryUseCase;
+import com.todaysfail.domains.user.usecase.UserWithDrawUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,14 +22,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
     private final UserMapper userMapper;
-    private final QueryUserUseCase queryUserUseCase;
+    private final UserQueryUseCase userQueryUseCase;
     private final RandomNicknameUseCase randomNicknameUseCase;
+    private final UserWithDrawUseCase userWithDrawUseCase;
 
     @SecurityRequirement(name = "access-token")
     @Operation(summary = "내 정보를 조회합니다.")
     @GetMapping("/me")
     public UserDetail queryMyInfo() {
-        return queryUserUseCase.queryMyInfo(SecurityUtils.getCurrentUserId());
+        return userQueryUseCase.queryMyInfo(SecurityUtils.getCurrentUserId());
+    }
+
+    @SecurityRequirement(name = "access-token")
+    @Operation(summary = "회원탈퇴")
+    @DeleteMapping("/me")
+    public void withdrawal() {
+        userWithDrawUseCase.execute(SecurityUtils.getCurrentUserId());
     }
 
     @Operation(summary = "사용 가능 한 랜덤 닉네임을 발급합니다.")


### PR DESCRIPTION
### 연관 이슈
- close #64 
### 작업내용
- feign config 생성 (kakao unlink가 Form Data 형식)
- 유저 탈퇴 도메인 로직 구현
유저 탈퇴 시 닉네임 `탈퇴한 사용자`로 변경 처리</br>
