### PR TITLE
[#67] ci: develop 브랜치 CI 단계에서 Sonar Cloud Test Coverage 측정

### DIFF
--- a/.github/workflows/develop_cicd.yml
+++ b/.github/workflows/develop_cicd.yml
@@ -22,6 +22,13 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
 
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:
@@ -31,6 +38,12 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
+
+      - name: test and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test sonar --info --stacktrace --no-daemon
 
       - name: build
         run: ./gradlew clean build -x test

--- a/.github/workflows/develop_pull_reqeust.yml
+++ b/.github/workflows/develop_pull_reqeust.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Start containers
         run: docker compose -f docker-compose-test.yml up -d
 
-      - name: test
-        run: ./gradlew test --info --stacktrace --no-daemon
-
       - name: test and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 연관 이슈
- close #67 
### 작업내용
- develop 브랜치 기준으로 Sonar Cloud Test Coverage가 측정되지 않아 CI 단계에서,
테스트 커버리지 측정 하도록 추가하였습니다.
- develop 브랜치로 pull request시 Test가 중복으로 돌아가는 문제를 해결하였습니다.