### PR TITLE
[#77] cicd: PRODUCTION 환경 배포 슬랙 메세지 수정

### DIFF
--- a/.github/workflows/production_cd.yml
+++ b/.github/workflows/production_cd.yml
@@ -62,7 +62,7 @@ jobs:
             ${{ github.event.inputs.version }}
             
             *배포 내역 보기*
-            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.version }}
+            https://github.com/TodaysFail/TodaysFail-Backend/releases/tag/v${{ github.event.inputs.version }}
       - name: Notify on failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2
@@ -78,4 +78,4 @@ jobs:
             ${{ github.event.inputs.version }}
             
             *배포 내역 보기*
-            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ github.event.inputs.version }}
+            https://github.com/TodaysFail/TodaysFail-Backend/releases/tag/v${{ github.event.inputs.version }}

--- a/.github/workflows/production_cicd.yml
+++ b/.github/workflows/production_cicd.yml
@@ -137,11 +137,8 @@ jobs:
             *배포 버전*
             ${{ needs.ci.outputs.VERSION }}
             
-            *배포 내역*
-            ${{ join(github.event.commits.*.message, '\n') }}
-            
             *배포 내역 보기*
-            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ needs.ci.outputs.VERSION }}
+            https://github.com/TodaysFail/TodaysFail-Backend/releases/tag/v${{ needs.ci.outputs.VERSION }}
       - name: Notify on failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2
@@ -157,8 +154,5 @@ jobs:
             *배포 버전*
             ${{ needs.ci.outputs.VERSION }}
             
-            *배포 내역*
-            ${{ join(github.event.commits.*.message, '\n') }}
-            
             *배포 내역 보기*
-            https://github.com/TodaysFail/TodaysFail-Backend/commit/${{ needs.ci.outputs.VERSION }}
+            https://github.com/TodaysFail/TodaysFail-Backend/releases/tag/v${{ needs.ci.outputs.VERSION }}


### PR DESCRIPTION
### 연관 이슈
- close #77
### 작업내용
- PRODUCTION 환경 배포 시 슬랙 메세지에 사용되는 커밋메세지는
릴리즈 태그 푸시 기준이라 내역이 존재하지 않아, 제거하였고
배포 내역 보기 링크도 변경하였습니다