### PR TITLE
[#84] feat: 데이터베이스 Replication 설정

### DIFF
--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/properties/EnableCommonConfigProperties.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/properties/EnableCommonConfigProperties.java
@@ -5,4 +5,4 @@ import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({OauthProperties.class, JwtProperties.class})
 @Configuration
-public class EnableConfigProperties {}
+public class EnableCommonConfigProperties {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReadOnlyDataSourceCycle.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReadOnlyDataSourceCycle.java
@@ -1,0 +1,21 @@
+package com.todaysfail.config.mysql;
+
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+
+@Profile({"prod", "dev"})
+public class ReadOnlyDataSourceCycle<T> {
+    private List<T> readOnlyDataSourceLookupKeys;
+    private int index = 0;
+
+    public void setReadOnlyDataSourceLookupKeys(List<T> readOnlyDataSourceLookupKeys) {
+        this.readOnlyDataSourceLookupKeys = readOnlyDataSourceLookupKeys;
+    }
+
+    public T getReadOnlyDataSourceLookupKey() {
+        if (index + 1 >= readOnlyDataSourceLookupKeys.size()) {
+            index = -1;
+        }
+        return readOnlyDataSourceLookupKeys.get(++index);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationDataSourceConfiguration.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationDataSourceConfiguration.java
@@ -1,0 +1,57 @@
+package com.todaysfail.config.mysql;
+
+import com.todaysfail.config.properties.ReplicationDataSourceProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+@RequiredArgsConstructor
+@Profile({"prod", "dev"})
+public class ReplicationDataSourceConfiguration {
+    private final ReplicationDataSourceProperties replicationDataSourceProperties;
+
+    @Bean
+    public DataSource routingDataSource() {
+        ReplicationRoutingDataSource replicationRoutingDataSource =
+                new ReplicationRoutingDataSource();
+
+        ReplicationDataSourceProperties.Master master = replicationDataSourceProperties.getMaster();
+        DataSource masterDataSource = createDataSource(master.getUrl());
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(master.getName(), masterDataSource);
+
+        List<ReplicationDataSourceProperties.Slave> slaves =
+                replicationDataSourceProperties.getSlave();
+        for (ReplicationDataSourceProperties.Slave slave : slaves) {
+            dataSourceMap.put(slave.getName(), createDataSource(slave.getUrl()));
+        }
+
+        replicationRoutingDataSource.setDefaultTargetDataSource(masterDataSource);
+        replicationRoutingDataSource.setTargetDataSources(dataSourceMap);
+        replicationRoutingDataSource.afterPropertiesSet();
+
+        return new LazyConnectionDataSourceProxy(replicationRoutingDataSource);
+    }
+
+    private DataSource createDataSource(String url) {
+        HikariDataSource hikariDataSource = new HikariDataSource();
+        hikariDataSource.setDriverClassName(replicationDataSourceProperties.getDriverClassName());
+        hikariDataSource.setUsername(replicationDataSourceProperties.getUsername());
+        hikariDataSource.setPassword(replicationDataSourceProperties.getPassword());
+        hikariDataSource.setJdbcUrl(url);
+        hikariDataSource.setMaxLifetime(
+                replicationDataSourceProperties.getHikari().getMaxLifetime());
+        hikariDataSource.setMaximumPoolSize(
+                replicationDataSourceProperties.getHikari().getMaximumPoolSize());
+        return hikariDataSource;
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationRoutingDataSource.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationRoutingDataSource.java
@@ -1,0 +1,36 @@
+package com.todaysfail.config.mysql;
+
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Profile({"prod", "dev"})
+@RequiredArgsConstructor
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+    private static final String MASTER = "master";
+    private static final String SLAVE = "slave";
+
+    private final ReadOnlyDataSourceCycle<String> readOnlyDataSourceCycle =
+            new ReadOnlyDataSourceCycle<>();
+
+    @Override
+    public void setTargetDataSources(Map<Object, Object> targetDataSources) {
+        super.setTargetDataSources(targetDataSources);
+        List<String> readOnlyDataSourceLookupKeys =
+                targetDataSources.keySet().stream()
+                        .map(String::valueOf)
+                        .filter(lookupKey -> lookupKey.contains(SLAVE))
+                        .toList();
+        readOnlyDataSourceCycle.setReadOnlyDataSourceLookupKeys(readOnlyDataSourceLookupKeys);
+    }
+
+    @Override
+    public Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly()
+                ? readOnlyDataSourceCycle.getReadOnlyDataSourceLookupKey()
+                : MASTER;
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/EnableInfrastructureConfigProperties.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/EnableInfrastructureConfigProperties.java
@@ -1,0 +1,8 @@
+package com.todaysfail.config.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties(ReplicationDataSourceProperties.class)
+@Configuration
+public class EnableInfrastructureConfigProperties {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/ReplicationDataSourceProperties.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/ReplicationDataSourceProperties.java
@@ -1,0 +1,43 @@
+package com.todaysfail.config.properties;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.context.annotation.Profile;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "spring.datasource")
+@ConstructorBinding
+@Profile({"prod", "dev"})
+public class ReplicationDataSourceProperties {
+    private String username;
+    private String password;
+    private String driverClassName;
+    private Master master;
+    private List<Slave> slave;
+    private Hikari hikari;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Master {
+        private String name;
+        private String url;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Slave {
+        private String name;
+        private String url;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Hikari {
+        private int maxLifetime;
+        private int maximumPoolSize;
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/TodaysFail-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -20,13 +20,13 @@ spring:
     activate:
       on-profile: local
   datasource:
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
     url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maxLifetime: 580000
       maximum-pool-size: 10
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
   jpa:
     show-sql: ${SHOW_SQL:true}
     properties:
@@ -54,13 +54,18 @@ spring:
     activate:
       on-profile: dev
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    master:
+      name: master
+      url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
+    slave:
+      - name: slave1
+        url: jdbc:mysql://${MYSQL_SLAVE1_HOST}:${MYSQL_SLAVE1_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
     hikari:
       maxLifetime: 580000
       maximum-pool-size: 20
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
   jpa:
     properties:
       hibernate:
@@ -78,13 +83,18 @@ spring:
     activate:
       on-profile: prod
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    master:
+      name: master
+      url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
+    slave:
+      - name: slave1
+        url: jdbc:mysql://${MYSQL_SLAVE1_HOST}:${MYSQL_SLAVE1_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
     hikari:
       maxLifetime: 580000
       maximum-pool-size: 20
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
   jpa:
     properties:
       hibernate:

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/auth/AuthController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/auth/AuthController.java
@@ -17,6 +17,7 @@ import com.todaysfail.domains.auth.usecase.RefreshUseCase;
 import com.todaysfail.domains.auth.usecase.RegisterUserUseCase;
 import com.todaysfail.domains.auth.usecase.UserLoginUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -108,6 +109,7 @@ public class AuthController {
         return authMapper.toTokenAndUserResponse(refreshUseCase.execute(refreshToken));
     }
 
+    @SecurityRequirement(name = "access-token")
     @Operation(summary = "로그아웃을 합니다.")
     @PostMapping("/logout")
     public void logout() {

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/UserController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/UserController.java
@@ -2,6 +2,7 @@ package com.todaysfail.api.web.user;
 
 import com.todaysfail.api.web.user.dto.response.RandomNicknameResponse;
 import com.todaysfail.api.web.user.mapper.UserMapper;
+import com.todaysfail.common.annotation.DisableSwaggerSecurity;
 import com.todaysfail.config.security.SecurityUtils;
 import com.todaysfail.domains.user.domain.UserDetail;
 import com.todaysfail.domains.user.usecase.RandomNicknameUseCase;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "2. [유저]")
 @RestController
 @RequestMapping("/api/v1/users")
+@SecurityRequirement(name = "access-token")
 @RequiredArgsConstructor
 public class UserController {
     private final UserMapper userMapper;
@@ -40,6 +42,7 @@ public class UserController {
         userWithDrawUseCase.execute(SecurityUtils.getCurrentUserId());
     }
 
+    @DisableSwaggerSecurity
     @Operation(summary = "사용 가능 한 랜덤 닉네임을 발급합니다.")
     @GetMapping("/nickname/generate")
     public RandomNicknameResponse generateRandomNickname() {

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/config/security/SecurityConfig.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/config/security/SecurityConfig.java
@@ -61,6 +61,8 @@ public class SecurityConfig {
                 .permitAll()
                 .mvcMatchers("/api/v1/auth/token/refresh")
                 .permitAll()
+                .antMatchers("/api/v1/users/nickname/generate")
+                .permitAll()
                 .anyRequest()
                 .hasRole("USER");
         http.apply(filterConfig);


### PR DESCRIPTION
### 연관 이슈
- close #84 
### 작업내용
- 데이터베이스 Replication 설정
- prod, dev 환경에서만 동작하도록 Profile 설정
- 추상클래스 AbstractRoutingDataSource를 상속받아, readOnly 속성이 걸려있을 때 slave로 조회되도록 라우팅