### PR TITLE
[#88] feat: Aws S3 PresignedUrl로 이미지 업로드, 이미지 조회

### DIFF
--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/consts/TodaysFailConst.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/consts/TodaysFailConst.java
@@ -31,6 +31,8 @@ public class TodaysFailConst {
     public static final String DEV_SERVER_URL = "https://dev.todaysfail.com";
     public static final String LOCAL_SERVER_URL = "http://localhost:8080";
 
+    public static final String IMAGE_DOMAIN = "https://image.todaysfail.com";
+
     public static final String[] SwaggerPatterns = {
         "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs",
     };

--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/type/image/ImageFileExtension.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/type/image/ImageFileExtension.java
@@ -1,0 +1,15 @@
+package com.todaysfail.common.type.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageFileExtension {
+    JPEG("jpeg"),
+    JPG("jpg"),
+    PNG("png"),
+    ;
+
+    private String uploadExtension;
+}

--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/type/image/ImageType.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/type/image/ImageType.java
@@ -1,0 +1,13 @@
+package com.todaysfail.common.type.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageType {
+    PROFILE("profile"),
+    ;
+
+    private String value;
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/domain/Image.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/domain/Image.java
@@ -1,0 +1,34 @@
+package com.todaysfail.domains.image.domain;
+
+import com.todaysfail.common.type.image.ImageType;
+import com.todaysfail.domains.image.entity.ImageEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Image {
+    private Long imageId;
+    private ImageType imageType;
+    private String imageKey;
+    private String imageUri;
+
+    private static Image from(ImageEntity userEntity) {
+        return new Image(
+                userEntity.getId(),
+                userEntity.getImageType(),
+                userEntity.getImageKey(),
+                userEntity.getImageUri());
+    }
+
+    public static Image of(ImageType imageType, String imageKey, String imageUri) {
+        return new Image(null, imageType, imageKey, imageUri);
+    }
+
+    public static Image registerUser(ImageEntity imageEntity) {
+        return Image.from(imageEntity);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/domain/Image.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/domain/Image.java
@@ -14,21 +14,17 @@ public class Image {
     private Long imageId;
     private ImageType imageType;
     private String imageKey;
-    private String imageUri;
+    private String imageUrl;
 
     private static Image from(ImageEntity userEntity) {
         return new Image(
                 userEntity.getId(),
                 userEntity.getImageType(),
                 userEntity.getImageKey(),
-                userEntity.getImageUri());
+                userEntity.getImageUrl());
     }
 
-    public static Image of(ImageType imageType, String imageKey, String imageUri) {
-        return new Image(null, imageType, imageKey, imageUri);
-    }
-
-    public static Image registerUser(ImageEntity imageEntity) {
+    public static Image registerImage(ImageEntity imageEntity) {
         return Image.from(imageEntity);
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/domain/PresignedUrl.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/domain/PresignedUrl.java
@@ -1,0 +1,18 @@
+package com.todaysfail.domains.image.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PresignedUrl {
+    private String presignUrl;
+    private String imageKey;
+
+    public static PresignedUrl of(String presignUrl, String imageKey) {
+        return new PresignedUrl(presignUrl, imageKey);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/service/GeneratePresignedUrlService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/service/GeneratePresignedUrlService.java
@@ -1,0 +1,80 @@
+package com.todaysfail.domains.image.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.todaysfail.common.helper.SpringEnvironmentHelper;
+import com.todaysfail.common.type.image.ImageFileExtension;
+import com.todaysfail.common.type.image.ImageType;
+import com.todaysfail.config.properties.AwsS3Properties;
+import com.todaysfail.domains.image.domain.PresignedUrl;
+import com.todaysfail.domains.image.port.PresignedUrlGeneratePort;
+import com.todaysfail.domains.image.usecase.GeneratePresignedUrlUseCase;
+import java.util.Date;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GeneratePresignedUrlService implements GeneratePresignedUrlUseCase {
+    private final AwsS3Properties awsS3Properties;
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+    private final PresignedUrlGeneratePort presignedUrlGeneratePort;
+
+    @Override
+    public PresignedUrl execute(
+            Long userId, ImageType imageType, ImageFileExtension imageFileExtension) {
+        String imageKey = UUID.randomUUID().toString();
+        String fileName = getFileName(userId, imageType, imageFileExtension, imageKey);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                getGeneratePreSignedUrlRequest(
+                        awsS3Properties.getBucket(),
+                        fileName,
+                        imageFileExtension.getUploadExtension());
+
+        String presignedUrl =
+                presignedUrlGeneratePort.generatePresignedUrl(
+                        fileName, generatePresignedUrlRequest);
+        return PresignedUrl.of(presignedUrl, imageKey);
+    }
+
+    private String getFileName(
+            Long userId,
+            ImageType imageType,
+            ImageFileExtension imageFileExtension,
+            String imageKey) {
+        return springEnvironmentHelper.getCurrentProfile()
+                + "/"
+                + imageType.getValue()
+                + "/"
+                + userId
+                + "/"
+                + imageKey
+                + "."
+                + imageFileExtension.getUploadExtension();
+    }
+
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(
+            String bucket, String fileName, String fileExtension) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
+                        .withKey(fileName)
+                        .withContentType("image/" + fileExtension)
+                        .withExpiration(getPreSignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        var expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 30;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/service/ImageUploadSuccessService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/service/ImageUploadSuccessService.java
@@ -1,0 +1,45 @@
+package com.todaysfail.domains.image.service;
+
+import com.todaysfail.common.consts.TodaysFailConst;
+import com.todaysfail.common.helper.SpringEnvironmentHelper;
+import com.todaysfail.common.type.image.ImageFileExtension;
+import com.todaysfail.common.type.image.ImageType;
+import com.todaysfail.domains.image.domain.Image;
+import com.todaysfail.domains.image.entity.ImageEntity;
+import com.todaysfail.domains.image.port.ImageCommandPort;
+import com.todaysfail.domains.image.usecase.ImageUploadSuccessUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUploadSuccessService implements ImageUploadSuccessUseCase {
+    private final ImageCommandPort imageCommandPort;
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+
+    @Override
+    public String success(
+            Long userId,
+            ImageType imageType,
+            ImageFileExtension imageFileExtension,
+            String imageKey) {
+        String imageUrl =
+                TodaysFailConst.IMAGE_DOMAIN
+                        + "/"
+                        + springEnvironmentHelper.getCurrentProfile()
+                        + "/"
+                        + imageType.getValue()
+                        + "/"
+                        + userId
+                        + "/"
+                        + imageKey
+                        + "."
+                        + imageFileExtension.getUploadExtension();
+        ImageEntity imageEntity =
+                ImageEntity.registerImage(
+                        userId, imageType, imageFileExtension, imageKey, imageUrl);
+        Image image = Image.registerImage(imageEntity);
+        imageCommandPort.save(imageEntity);
+        return image.getImageUrl();
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/usecase/GeneratePresignedUrlUseCase.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/usecase/GeneratePresignedUrlUseCase.java
@@ -1,0 +1,10 @@
+package com.todaysfail.domains.image.usecase;
+
+import com.todaysfail.common.type.image.ImageFileExtension;
+import com.todaysfail.common.type.image.ImageType;
+import com.todaysfail.domains.image.domain.PresignedUrl;
+
+public interface GeneratePresignedUrlUseCase {
+
+    PresignedUrl execute(Long userId, ImageType imageType, ImageFileExtension imageFileExtension);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/usecase/ImageUploadSuccessUseCase.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/image/usecase/ImageUploadSuccessUseCase.java
@@ -1,0 +1,12 @@
+package com.todaysfail.domains.image.usecase;
+
+import com.todaysfail.common.type.image.ImageFileExtension;
+import com.todaysfail.common.type.image.ImageType;
+
+public interface ImageUploadSuccessUseCase {
+    String success(
+            Long userId,
+            ImageType imageType,
+            ImageFileExtension imageFileExtension,
+            String imageKey);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserRegisterService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserRegisterService.java
@@ -46,7 +46,6 @@ public class UserRegisterService implements UserRegisterUseCase {
     public Boolean checkUserCanRegister(OauthInfo oauthInfo) {
         Boolean aBoolean =
                 userQueryPort.existsByOauthInfo(oauthInfo.getOauthId(), oauthInfo.getProvider());
-        System.out.println("aBoolean = " + aBoolean);
         return aBoolean;
     }
 

--- a/TodaysFail-Infrastructure/build.gradle
+++ b/TodaysFail-Infrastructure/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-redis'
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api ("org.redisson:redisson:3.19.0")
+    api ("com.amazonaws:aws-java-sdk-s3:1.12.476")
 
     implementation ("io.github.openfeign:feign-httpclient:12.1")
     implementation ("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/AwsS3Properties.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/AwsS3Properties.java
@@ -1,0 +1,17 @@
+package com.todaysfail.config.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "aws.s3")
+@ConstructorBinding
+public class AwsS3Properties {
+    private String accessKey;
+    private String secretKey;
+    private String region;
+    private String bucket;
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/EnableInfrastructureConfigProperties.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/properties/EnableInfrastructureConfigProperties.java
@@ -3,6 +3,6 @@ package com.todaysfail.config.properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties(ReplicationDataSourceProperties.class)
+@EnableConfigurationProperties({ReplicationDataSourceProperties.class, AwsS3Properties.class})
 @Configuration
 public class EnableInfrastructureConfigProperties {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/s3/S3Config.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/s3/S3Config.java
@@ -1,0 +1,28 @@
+package com.todaysfail.config.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.todaysfail.config.properties.AwsS3Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+    private final AwsS3Properties awsS3Properties;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials =
+                new BasicAWSCredentials(
+                        awsS3Properties.getAccessKey(), awsS3Properties.getSecretKey());
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(awsS3Properties.getRegion())
+                .build();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/adapter/ImageCommandAdapter.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/adapter/ImageCommandAdapter.java
@@ -1,8 +1,20 @@
 package com.todaysfail.domains.image.adapter;
 
 import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.image.entity.ImageEntity;
+import com.todaysfail.domains.image.port.ImageCommandPort;
+import com.todaysfail.domains.image.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @Adapter
 @Transactional
-public class ImageCommandAdapter {}
+@RequiredArgsConstructor
+public class ImageCommandAdapter implements ImageCommandPort {
+    private final ImageRepository imageRepository;
+
+    @Override
+    public ImageEntity save(ImageEntity imageEntity) {
+        return imageRepository.save(imageEntity);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/adapter/ImageCommandAdapter.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/adapter/ImageCommandAdapter.java
@@ -1,0 +1,8 @@
+package com.todaysfail.domains.image.adapter;
+
+import com.todaysfail.common.annotation.Adapter;
+import org.springframework.transaction.annotation.Transactional;
+
+@Adapter
+@Transactional
+public class ImageCommandAdapter {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/adapter/PresignedUrlGenerateAdapter.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/adapter/PresignedUrlGenerateAdapter.java
@@ -1,0 +1,18 @@
+package com.todaysfail.domains.image.adapter;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.image.port.PresignedUrlGeneratePort;
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class PresignedUrlGenerateAdapter implements PresignedUrlGeneratePort {
+    private final AmazonS3 amazonS3;
+
+    @Override
+    public String generatePresignedUrl(String fileName, GeneratePresignedUrlRequest request) {
+        return amazonS3.generatePresignedUrl(request).toString();
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/entity/ImageEntity.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/entity/ImageEntity.java
@@ -1,5 +1,6 @@
 package com.todaysfail.domains.image.entity;
 
+import com.todaysfail.common.type.image.ImageFileExtension;
 import com.todaysfail.common.type.image.ImageType;
 import com.todaysfail.domains.BaseTimeEntity;
 import javax.persistence.Entity;
@@ -20,25 +21,49 @@ public class ImageEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Long userId;
+
     @Enumerated(EnumType.STRING)
     private ImageType imageType;
 
+    @Enumerated(EnumType.STRING)
+    private ImageFileExtension imageFileExtension;
+
     private String imageKey;
 
-    private String imageUri;
+    private String imageUrl;
 
-    private ImageEntity(Long id, ImageType imageType, String imageKey, String imageUri) {
+    private ImageEntity(
+            Long id,
+            Long userId,
+            ImageType imageType,
+            ImageFileExtension imageFileExtension,
+            String imageKey,
+            String imageUrl) {
         this.id = id;
+        this.userId = userId;
         this.imageType = imageType;
+        this.imageFileExtension = imageFileExtension;
         this.imageKey = imageKey;
-        this.imageUri = imageUri;
+        this.imageUrl = imageUrl;
     }
 
-    public static ImageEntity registerImage(ImageType imageType, String imageKey, String imageUri) {
-        return new ImageEntity(null, imageType, imageKey, imageUri);
+    public static ImageEntity registerImage(
+            Long userId,
+            ImageType imageType,
+            ImageFileExtension imageFileExtension,
+            String imageKey,
+            String imageUrl) {
+        return new ImageEntity(null, userId, imageType, imageFileExtension, imageKey, imageUrl);
     }
 
-    public static ImageEntity from(Long id, ImageType imageType, String imageKey, String imageUri) {
-        return new ImageEntity(id, imageType, imageKey, imageUri);
+    public static ImageEntity of(
+            Long id,
+            Long userId,
+            ImageType imageType,
+            ImageFileExtension imageFileExtension,
+            String imageKey,
+            String imageUrl) {
+        return new ImageEntity(id, userId, imageType, imageFileExtension, imageKey, imageUrl);
     }
 }

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/entity/ImageEntity.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/entity/ImageEntity.java
@@ -1,0 +1,44 @@
+package com.todaysfail.domains.image.entity;
+
+import com.todaysfail.common.type.image.ImageType;
+import com.todaysfail.domains.BaseTimeEntity;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity(name = "tbl_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ImageType imageType;
+
+    private String imageKey;
+
+    private String imageUri;
+
+    private ImageEntity(Long id, ImageType imageType, String imageKey, String imageUri) {
+        this.id = id;
+        this.imageType = imageType;
+        this.imageKey = imageKey;
+        this.imageUri = imageUri;
+    }
+
+    public static ImageEntity registerImage(ImageType imageType, String imageKey, String imageUri) {
+        return new ImageEntity(null, imageType, imageKey, imageUri);
+    }
+
+    public static ImageEntity from(Long id, ImageType imageType, String imageKey, String imageUri) {
+        return new ImageEntity(id, imageType, imageKey, imageUri);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/port/ImageCommandPort.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/port/ImageCommandPort.java
@@ -1,0 +1,3 @@
+package com.todaysfail.domains.image.port;
+
+public interface ImageCommandPort {}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/port/ImageCommandPort.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/port/ImageCommandPort.java
@@ -1,3 +1,7 @@
 package com.todaysfail.domains.image.port;
 
-public interface ImageCommandPort {}
+import com.todaysfail.domains.image.entity.ImageEntity;
+
+public interface ImageCommandPort {
+    ImageEntity save(ImageEntity imageEntity);
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/port/PresignedUrlGeneratePort.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/port/PresignedUrlGeneratePort.java
@@ -1,0 +1,7 @@
+package com.todaysfail.domains.image.port;
+
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+
+public interface PresignedUrlGeneratePort {
+    String generatePresignedUrl(String fileName, GeneratePresignedUrlRequest request);
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/repository/ImageRepository.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/domains/image/repository/ImageRepository.java
@@ -1,0 +1,6 @@
+package com.todaysfail.domains.image.repository;
+
+import com.todaysfail.domains.image.entity.ImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<ImageEntity, Long> {}

--- a/TodaysFail-Infrastructure/src/main/resources/application-infrastructure.yml
+++ b/TodaysFail-Infrastructure/src/main/resources/application-infrastructure.yml
@@ -7,6 +7,12 @@ feign:
   kakao:
     info : https://kapi.kakao.com
     oauth : https://kauth.kakao.com
+aws:
+  s3:
+    access-key: ${AWS_S3_ACCESS_KEY:}
+    secret-key: ${AWS_S3_SECRET_KEY:}
+    bucket: ${AWS_S3_BUCKET:}
+    region: ${AWS_S3_REGION:}
 ---
 spring:
   config:

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/ImageController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/ImageController.java
@@ -1,0 +1,38 @@
+package com.todaysfail.api.web.image;
+
+import com.todaysfail.api.web.image.dto.response.PresignedUrlResponse;
+import com.todaysfail.api.web.image.mapper.ImageMapper;
+import com.todaysfail.common.type.image.ImageFileExtension;
+import com.todaysfail.common.type.image.ImageType;
+import com.todaysfail.config.security.SecurityUtils;
+import com.todaysfail.domains.image.usecase.GeneratePresignedUrlUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "3. [이미지]")
+@RestController
+@RequestMapping("/api/v1/images")
+@SecurityRequirement(name = "access-token")
+@RequiredArgsConstructor
+public class ImageController {
+    private final ImageMapper imageMapper;
+    private final GeneratePresignedUrlUseCase generatePresignedUrlUseCase;
+
+    @Operation(summary = "이미지 업로드를 위한 presigned url을 생성합니다.")
+    @GetMapping("/presigned-url")
+    public PresignedUrlResponse generatePresignedUrl(
+            @Parameter(description = "이미지 타입", required = true) @RequestParam ImageType imageType,
+            @Parameter(description = "이미지 파일의 확장자", required = true) @RequestParam
+                    ImageFileExtension imageFileExtension) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return imageMapper.toPresignedUrlResponse(
+                generatePresignedUrlUseCase.execute(userId, imageType, imageFileExtension));
+    }
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/ImageController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/ImageController.java
@@ -1,11 +1,13 @@
 package com.todaysfail.api.web.image;
 
+import com.todaysfail.api.web.image.dto.response.ImageResponse;
 import com.todaysfail.api.web.image.dto.response.PresignedUrlResponse;
 import com.todaysfail.api.web.image.mapper.ImageMapper;
 import com.todaysfail.common.type.image.ImageFileExtension;
 import com.todaysfail.common.type.image.ImageType;
 import com.todaysfail.config.security.SecurityUtils;
 import com.todaysfail.domains.image.usecase.GeneratePresignedUrlUseCase;
+import com.todaysfail.domains.image.usecase.ImageUploadSuccessUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ImageController {
     private final ImageMapper imageMapper;
     private final GeneratePresignedUrlUseCase generatePresignedUrlUseCase;
+    private final ImageUploadSuccessUseCase imageUploadSuccessUseCase;
 
     @Operation(summary = "이미지 업로드를 위한 presigned url을 생성합니다.")
     @GetMapping("/presigned-url")
@@ -34,5 +37,18 @@ public class ImageController {
         Long userId = SecurityUtils.getCurrentUserId();
         return imageMapper.toPresignedUrlResponse(
                 generatePresignedUrlUseCase.execute(userId, imageType, imageFileExtension));
+    }
+
+    @Operation(summary = "이미지 업로드 성공 시 호출합니다.")
+    @GetMapping("/presigned-url/success")
+    public ImageResponse successGeneratePresignedUrl(
+            @Parameter(description = "이미지 타입", required = true) @RequestParam ImageType imageType,
+            @Parameter(description = "이미지 파일의 확장자", required = true) @RequestParam
+                    ImageFileExtension imageFileExtension,
+            @Parameter(description = "이미지 파일의 키", required = true) @RequestParam String imageKey) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        String imageUrl =
+                imageUploadSuccessUseCase.success(userId, imageType, imageFileExtension, imageKey);
+        return imageMapper.toImageResponse(imageUrl);
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/dto/response/ImageResponse.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/dto/response/ImageResponse.java
@@ -1,0 +1,3 @@
+package com.todaysfail.api.web.image.dto.response;
+
+public record ImageResponse(String imageUrl) {}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/dto/response/PresignedUrlResponse.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,3 @@
+package com.todaysfail.api.web.image.dto.response;
+
+public record PresignedUrlResponse(String presignedUrl, String imageKey) {}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/mapper/ImageMapper.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/mapper/ImageMapper.java
@@ -1,5 +1,6 @@
 package com.todaysfail.api.web.image.mapper;
 
+import com.todaysfail.api.web.image.dto.response.ImageResponse;
 import com.todaysfail.api.web.image.dto.response.PresignedUrlResponse;
 import com.todaysfail.common.annotation.Mapper;
 import com.todaysfail.domains.image.domain.PresignedUrl;
@@ -8,5 +9,9 @@ import com.todaysfail.domains.image.domain.PresignedUrl;
 public class ImageMapper {
     public PresignedUrlResponse toPresignedUrlResponse(PresignedUrl presignedUrl) {
         return new PresignedUrlResponse(presignedUrl.getPresignUrl(), presignedUrl.getImageKey());
+    }
+
+    public ImageResponse toImageResponse(String imageUrl) {
+        return new ImageResponse(imageUrl);
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/mapper/ImageMapper.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/image/mapper/ImageMapper.java
@@ -1,0 +1,12 @@
+package com.todaysfail.api.web.image.mapper;
+
+import com.todaysfail.api.web.image.dto.response.PresignedUrlResponse;
+import com.todaysfail.common.annotation.Mapper;
+import com.todaysfail.domains.image.domain.PresignedUrl;
+
+@Mapper
+public class ImageMapper {
+    public PresignedUrlResponse toPresignedUrlResponse(PresignedUrl presignedUrl) {
+        return new PresignedUrlResponse(presignedUrl.getPresignUrl(), presignedUrl.getImageKey());
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #88 
### 작업내용
- Aws S3 연동하여 PresignedUrl 발급하여, 업로드 파일이 서버를 거치지 않고 client에서 직접 업로드 하도록 구현