### PR TITLE
[#117] feat: 실패 기록 피드 기능

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureQueryAdapter.java
@@ -1,0 +1,22 @@
+package com.todaysfail.domains.failure.adapter;
+
+import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.failure.port.FailureQueryPort;
+import com.todaysfail.domains.failure.repository.FailureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+@Adapter
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FailureQueryAdapter implements FailureQueryPort {
+    private final FailureRepository failureRepository;
+
+    @Override
+    public Slice<Failure> queryFeed(Pageable pageable) {
+        return failureRepository.findAllBySecretFalseOrderByFailureDateDesc(pageable);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/domain/Failure.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/domain/Failure.java
@@ -32,11 +32,11 @@ public class Failure {
     @Column(name = "failure_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "category_id")
     private Category category;
 
@@ -48,7 +48,7 @@ public class Failure {
 
     private String impression;
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.EAGER)
     @JoinColumn(name = "failure_id")
     private Set<Tag> tags = new HashSet<>();
 

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureQueryPort.java
@@ -1,0 +1,9 @@
+package com.todaysfail.domains.failure.port;
+
+import com.todaysfail.domains.failure.domain.Failure;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface FailureQueryPort {
+    Slice<Failure> queryFeed(Pageable pageable);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/repository/FailureRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/repository/FailureRepository.java
@@ -1,6 +1,10 @@
 package com.todaysfail.domains.failure.repository;
 
 import com.todaysfail.domains.failure.domain.Failure;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FailureRepository extends JpaRepository<Failure, Long> {}
+public interface FailureRepository extends JpaRepository<Failure, Long> {
+    Slice<Failure> findAllBySecretFalseOrderByFailureDateDesc(Pageable pageable);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/service/FailureFeedQueryService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/service/FailureFeedQueryService.java
@@ -1,0 +1,19 @@
+package com.todaysfail.domains.failure.service;
+
+import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.failure.port.FailureQueryPort;
+import com.todaysfail.domains.failure.usecase.FailureFeedQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FailureFeedQueryService implements FailureFeedQueryUseCase {
+    private final FailureQueryPort failureQueryPort;
+
+    @Override
+    public Slice<Failure> execute(Query query) {
+        return failureQueryPort.queryFeed(query.pageable());
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/usecase/FailureFeedQueryUseCase.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/usecase/FailureFeedQueryUseCase.java
@@ -1,0 +1,11 @@
+package com.todaysfail.domains.failure.usecase;
+
+import com.todaysfail.domains.failure.domain.Failure;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface FailureFeedQueryUseCase {
+    Slice<Failure> execute(Query query);
+
+    record Query(Pageable pageable) {}
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/FailureController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/FailureController.java
@@ -1,16 +1,22 @@
 package com.todaysfail.api.web.failure;
 
+import com.todaysfail.api.web.common.SliceResponse;
 import com.todaysfail.api.web.failure.dto.request.FailureRegisterRequest;
 import com.todaysfail.api.web.failure.dto.response.FailureResponse;
 import com.todaysfail.api.web.failure.mapper.FailureMapper;
 import com.todaysfail.config.security.SecurityUtils;
 import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.failure.usecase.FailureFeedQueryUseCase;
 import com.todaysfail.domains.failure.usecase.FailureRegisterUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FailureController {
     private final FailureMapper failureMapper;
     private final FailureRegisterUseCase failureRegisterUseCase;
+    private final FailureFeedQueryUseCase failureFeedQueryUseCase;
 
     @Operation(summary = "실패 등록")
     @PostMapping
@@ -41,5 +48,13 @@ public class FailureController {
                                 request.tagSet(),
                                 request.secret()));
         return failureMapper.toFailureResponse(failure);
+    }
+
+    @Operation(summary = "피드")
+    @GetMapping("/feed")
+    public SliceResponse<FailureResponse> queryFeed(
+            @ParameterObject @PageableDefault final Pageable pageable) {
+        return failureMapper.toFailureSliceResponse(
+                failureFeedQueryUseCase.execute(new FailureFeedQueryUseCase.Query(pageable)));
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/dto/response/FailureResponse.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/dto/response/FailureResponse.java
@@ -16,4 +16,5 @@ public record FailureResponse(
         String impression,
         Set<TagResponse> tagList,
         int heartCount,
-        boolean secret) {}
+        boolean secret,
+        boolean isMine) {}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/mapper/FailureMapper.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/mapper/FailureMapper.java
@@ -1,12 +1,15 @@
 package com.todaysfail.api.web.failure.mapper;
 
 import com.todaysfail.api.web.category.mapper.CategoryMapper;
+import com.todaysfail.api.web.common.SliceResponse;
 import com.todaysfail.api.web.failure.dto.response.FailureResponse;
 import com.todaysfail.api.web.tag.mapper.TagMapper;
 import com.todaysfail.common.annotation.Mapper;
 import com.todaysfail.common.vo.UserDetail;
+import com.todaysfail.config.security.SecurityUtils;
 import com.todaysfail.domains.failure.domain.Failure;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 @Mapper
 @RequiredArgsConstructor
@@ -15,6 +18,8 @@ public class FailureMapper {
     private final TagMapper tagMapper;
 
     public FailureResponse toFailureResponse(Failure failure) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        boolean isMine = failure.getUser().getId().equals(userId);
         return new FailureResponse(
                 failure.getId(),
                 UserDetail.from(failure.getUser()),
@@ -25,6 +30,11 @@ public class FailureMapper {
                 failure.getImpression(),
                 tagMapper.toTagResponseSet(failure.getTags()),
                 failure.getHeartCount(),
-                failure.isSecret());
+                failure.isSecret(),
+                isMine);
+    }
+
+    public SliceResponse<FailureResponse> toFailureSliceResponse(Slice<Failure> failureSlice) {
+        return SliceResponse.of(failureSlice.map(failure -> toFailureResponse(failure)));
     }
 }


### PR DESCRIPTION
### 연관 이슈
- close #117 
### 작업내용
- 실패 기록 피드 기능 구현
- client에서 인피니티 스크롤로 구현되는 화면이라 page와 size 선택 하여 SliceResponse 객체로 return
- 본인 글 여부인지 확인 할 수 있도록 isMine 필드 추가