### PR TITLE
[#122] feat: 실패 좋아요 기능

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureCommandAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureCommandAdapter.java
@@ -2,6 +2,7 @@ package com.todaysfail.domains.failure.adapter;
 
 import com.todaysfail.common.annotation.Adapter;
 import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.failure.exception.FailureNotFoundException;
 import com.todaysfail.domains.failure.port.FailureCommandPort;
 import com.todaysfail.domains.failure.repository.FailureRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,5 +17,12 @@ public class FailureCommandAdapter implements FailureCommandPort {
     @Override
     public Failure save(Failure failure) {
         return failureRepository.save(failure);
+    }
+
+    @Override
+    public Failure queryFailure(Long failureId) {
+        return failureRepository
+                .findById(failureId)
+                .orElseThrow(() -> FailureNotFoundException.EXCEPTION);
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/domain/Failure.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/domain/Failure.java
@@ -2,6 +2,7 @@ package com.todaysfail.domains.failure.domain;
 
 import com.todaysfail.common.BaseTimeEntity;
 import com.todaysfail.config.converter.LongArrayConverter;
+import com.todaysfail.domains.failure.exception.FailureOwnedByUserException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,5 +50,16 @@ public class Failure extends BaseTimeEntity {
 
     public boolean isMine(Long userId) {
         return this.userId.equals(userId);
+    }
+
+    public void like() {
+        this.heartCount++;
+    }
+
+    public void validateOwnership(Long userId) {
+        // 본인이 생성 한 실패 기록일 경우
+        if (this.userId.equals(userId)) {
+            throw FailureOwnedByUserException.EXCEPTION;
+        }
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/exception/FailureNotFoundException.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/exception/FailureNotFoundException.java
@@ -1,0 +1,11 @@
+package com.todaysfail.domains.failure.exception;
+
+import com.todaysfail.common.exception.TodaysFailCodeException;
+
+public class FailureNotFoundException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new FailureNotFoundException();
+
+    public FailureNotFoundException() {
+        super(FailureErrorCode.FAILURE_NOT_FOUND);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/exception/FailureOwnedByUserException.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/exception/FailureOwnedByUserException.java
@@ -1,0 +1,11 @@
+package com.todaysfail.domains.failure.exception;
+
+import com.todaysfail.common.exception.TodaysFailCodeException;
+
+public class FailureOwnedByUserException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new FailureOwnedByUserException();
+
+    public FailureOwnedByUserException() {
+        super(FailureErrorCode.FAILURE_OWNED_BY_USER);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureCommandPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureCommandPort.java
@@ -4,4 +4,6 @@ import com.todaysfail.domains.failure.domain.Failure;
 
 public interface FailureCommandPort {
     Failure save(Failure failure);
+
+    Failure queryFailure(Long failureId);
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/service/FailureDomainService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/service/FailureDomainService.java
@@ -1,19 +1,26 @@
 package com.todaysfail.domains.failure.service;
 
+import com.todaysfail.aop.lock.RedissonLock;
 import com.todaysfail.domains.category.domain.Category;
 import com.todaysfail.domains.failure.domain.Failure;
 import com.todaysfail.domains.failure.exception.FutureFailureDateException;
 import com.todaysfail.domains.failure.port.FailureCommandPort;
+import com.todaysfail.domains.like.domain.FailureLike;
+import com.todaysfail.domains.like.port.FailureLikeCommandPort;
+import com.todaysfail.domains.like.port.FailureLikeQueryPort;
 import com.todaysfail.domains.tag.exception.TagCountExceedException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FailureDomainService {
     private final FailureCommandPort failureCommandPort;
+    private final FailureLikeCommandPort failureLikeCommandPort;
+    private final FailureLikeQueryPort failureLikeQueryPort;
 
     public Failure register(final Failure failure, Category category) {
         validateFailureTagSize(failure.getTags());
@@ -33,5 +40,15 @@ public class FailureDomainService {
         if (date.isAfter(LocalDate.now())) {
             throw FutureFailureDateException.EXCEPTION;
         }
+    }
+
+    @Transactional
+    @RedissonLock(lockName = "실패좋아요", identifier = "failureId")
+    public void likeFailure(Long userId, Long failureId) {
+        Failure failure = failureCommandPort.queryFailure(failureId);
+        failure.validateOwnership(userId);
+        failure.like();
+        failureLikeQueryPort.checkAlreadyLiked(userId, failureId);
+        failureLikeCommandPort.save(FailureLike.of(userId, failureId));
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/adapter/FailureLikeCommandAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/adapter/FailureLikeCommandAdapter.java
@@ -1,0 +1,20 @@
+package com.todaysfail.domains.like.adapter;
+
+import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.like.domain.FailureLike;
+import com.todaysfail.domains.like.port.FailureLikeCommandPort;
+import com.todaysfail.domains.like.repository.FailureLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Adapter
+@Transactional
+@RequiredArgsConstructor
+public class FailureLikeCommandAdapter implements FailureLikeCommandPort {
+    private final FailureLikeRepository failureLikeRepository;
+
+    @Override
+    public FailureLike save(FailureLike failureLike) {
+        return failureLikeRepository.save(failureLike);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/adapter/FailureLikeQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/adapter/FailureLikeQueryAdapter.java
@@ -1,0 +1,26 @@
+package com.todaysfail.domains.like.adapter;
+
+import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.like.domain.FailureLike;
+import com.todaysfail.domains.like.exception.FailureLikeAlreadyLikedException;
+import com.todaysfail.domains.like.port.FailureLikeQueryPort;
+import com.todaysfail.domains.like.repository.FailureLikeRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Adapter
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FailureLikeQueryAdapter implements FailureLikeQueryPort {
+    private final FailureLikeRepository failureLikeRepository;
+
+    @Override
+    public void checkAlreadyLiked(Long userId, Long failureId) {
+        Optional<FailureLike> failureLikeOptional =
+                failureLikeRepository.findByUserIdAndFailureId(userId, failureId);
+        if (failureLikeOptional.isPresent()) {
+            throw FailureLikeAlreadyLikedException.EXCEPTION;
+        }
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/domain/FailureLike.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/domain/FailureLike.java
@@ -1,0 +1,33 @@
+package com.todaysfail.domains.like.domain;
+
+import com.todaysfail.common.BaseTimeEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity(name = "tbl_failure_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FailureLike extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "failure_like_id")
+    private Long id;
+
+    private Long userId;
+
+    private Long failureId;
+
+    public static FailureLike of(Long userId, Long failureId) {
+        return FailureLike.builder().userId(userId).failureId(failureId).build();
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/exception/FailureLikeAlreadyLikedException.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/exception/FailureLikeAlreadyLikedException.java
@@ -1,0 +1,11 @@
+package com.todaysfail.domains.like.exception;
+
+import com.todaysfail.common.exception.TodaysFailCodeException;
+
+public class FailureLikeAlreadyLikedException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new FailureLikeAlreadyLikedException();
+
+    public FailureLikeAlreadyLikedException() {
+        super(FailureLikeErrorCode.FAILURE_LIKE_ALREADY_LIKED);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/exception/FailureLikeErrorCode.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/exception/FailureLikeErrorCode.java
@@ -1,4 +1,4 @@
-package com.todaysfail.domains.failure.exception;
+package com.todaysfail.domains.like.exception;
 
 import static com.todaysfail.common.consts.TodaysFailConst.*;
 
@@ -12,15 +12,9 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum FailureErrorCode implements BaseErrorCode {
-    @ExplainError("실패 기록을 찾을 수 없을 때")
-    FAILURE_NOT_FOUND(NOT_FOUND, "FAILURE_400_1", "실패를 찾을 수 없습니다."),
-
-    @ExplainError("입력 한 날짜가 미래일 수 없습니다.")
-    FAILURE_DATE_IS_FUTURE(NOT_FOUND, "FAILURE_400_2", "입력 한 날짜가 미래일 수 없습니다."),
-
-    @ExplainError("본인이 생성한 실패 기록 입니다.")
-    FAILURE_OWNED_BY_USER(BAD_REQUEST, "FAILURE_400_3", "본인이 생성한 실패 기록 입니다."),
+public enum FailureLikeErrorCode implements BaseErrorCode {
+    @ExplainError("이미 좋아요 한 실패 게시물인 경우")
+    FAILURE_LIKE_ALREADY_LIKED(BAD_REQUEST, "FAILURE_LIKE_400_1", "이미 좋아요 한 실패 게시물인 경우"),
     ;
 
     private Integer status;

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/port/FailureLikeCommandPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/port/FailureLikeCommandPort.java
@@ -1,0 +1,7 @@
+package com.todaysfail.domains.like.port;
+
+import com.todaysfail.domains.like.domain.FailureLike;
+
+public interface FailureLikeCommandPort {
+    FailureLike save(FailureLike failureLikee);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/port/FailureLikeQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/port/FailureLikeQueryPort.java
@@ -1,0 +1,5 @@
+package com.todaysfail.domains.like.port;
+
+public interface FailureLikeQueryPort {
+    void checkAlreadyLiked(Long userId, Long failureId);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/repository/FailureLikeRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/like/repository/FailureLikeRepository.java
@@ -1,0 +1,9 @@
+package com.todaysfail.domains.like.repository;
+
+import com.todaysfail.domains.like.domain.FailureLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FailureLikeRepository extends JpaRepository<FailureLike, Long> {
+    Optional<FailureLike> findByUserIdAndFailureId(Long userId, Long failureId);
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/FailureController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/FailureController.java
@@ -3,8 +3,8 @@ package com.todaysfail.api.web.failure;
 import com.todaysfail.api.web.common.SliceResponse;
 import com.todaysfail.api.web.failure.dto.request.FailureRegisterRequest;
 import com.todaysfail.api.web.failure.dto.response.FailureResponse;
-import com.todaysfail.api.web.failure.mapper.FailureMapper;
 import com.todaysfail.api.web.failure.usecase.FailureFeedQueryUseCase;
+import com.todaysfail.api.web.failure.usecase.FailureLikeUseCase;
 import com.todaysfail.api.web.failure.usecase.FailureRegisterUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -15,6 +15,7 @@ import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,9 +27,9 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "access-token")
 @RequiredArgsConstructor
 public class FailureController {
-    private final FailureMapper failureMapper;
     private final FailureRegisterUseCase failureRegisterUseCase;
     private final FailureFeedQueryUseCase failureFeedQueryUseCase;
+    private final FailureLikeUseCase failureLikeUseCase;
 
     @Operation(summary = "실패 등록")
     @PostMapping
@@ -41,5 +42,11 @@ public class FailureController {
     public SliceResponse<FailureResponse> queryFeed(
             @ParameterObject @PageableDefault final Pageable pageable) {
         return failureFeedQueryUseCase.execute(pageable);
+    }
+
+    @Operation(summary = "실패 좋아요")
+    @PostMapping("/like/{failureId}")
+    public void likeFailure(@PathVariable Long failureId) {
+        failureLikeUseCase.execute(failureId);
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureLikeUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureLikeUseCase.java
@@ -1,0 +1,17 @@
+package com.todaysfail.api.web.failure.usecase;
+
+import com.todaysfail.common.annotation.UseCase;
+import com.todaysfail.config.security.SecurityUtils;
+import com.todaysfail.domains.failure.service.FailureDomainService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class FailureLikeUseCase {
+    private final FailureDomainService failureDomainService;
+
+    public void execute(final Long failureId) {
+        final Long userId = SecurityUtils.getCurrentUserId();
+        failureDomainService.likeFailure(userId, failureId);
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #122 
### 작업내용
- 실패 좋아요 기능
- 실패 좋아요를 기록할 수 있도록 FailureLike 매핑 테이블 생성
- 동시성 제어를 위해 Redission을 사용하여 RedissonLock 어노테이션으로 제어