### PR TITLE
[#108] feat: 태그 검색과 많이 기록된 태그 조회 기능

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/adapter/TagCommandAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/adapter/TagCommandAdapter.java
@@ -23,12 +23,12 @@ public class TagCommandAdapter implements TagCommandPort {
                         tagName ->
                                 tagRepository
                                         .findByTagName(tagName)
-                                        .orElseGet(
-                                                () ->
-                                                        tagRepository.save(
-                                                                Tag.builder()
-                                                                        .tagName(tagName)
-                                                                        .build())))
+                                        .orElseGet(() -> tagRepository.save(Tag.register(tagName))))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Tag> saveAll(List<Tag> tags) {
+        return tagRepository.saveAll(tags);
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/adapter/TagQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/adapter/TagQueryAdapter.java
@@ -32,4 +32,14 @@ public class TagQueryAdapter implements TagQueryPort {
     public List<Tag> queryAllByIds(List<Long> tags) {
         return tagRepository.findAllById(tags);
     }
+
+    @Override
+    public List<Tag> querySearch(String searchKeyword) {
+        return tagRepository.findTop5ByTagNameContainsIgnoreCase(searchKeyword);
+    }
+
+    @Override
+    public List<Tag> queryPopular() {
+        return tagRepository.findTop5ByOrderByUsedCountDesc();
+    }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/domain/Tag.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/domain/Tag.java
@@ -24,4 +24,14 @@ public class Tag extends BaseTimeEntity {
     private Long id;
 
     private String tagName;
+
+    private Long usedCount;
+
+    public static Tag register(String tagName) {
+        return Tag.builder().tagName(tagName).usedCount(0L).build();
+    }
+
+    public void increaseUsedCount() {
+        this.usedCount++;
+    }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/port/TagCommandPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/port/TagCommandPort.java
@@ -6,4 +6,6 @@ import java.util.Set;
 
 public interface TagCommandPort {
     List<Tag> saveAndRetrieveAllTags(Set<String> tagNameSet);
+
+    List<Tag> saveAll(List<Tag> tags);
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/port/TagQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/port/TagQueryPort.java
@@ -8,4 +8,8 @@ public interface TagQueryPort {
     List<Tag> queryAllByNames(Set<String> tags);
 
     List<Tag> queryAllByIds(List<Long> tags);
+
+    List<Tag> querySearch(String searchKeyword);
+
+    List<Tag> queryPopular();
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/repository/TagRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/repository/TagRepository.java
@@ -1,9 +1,14 @@
 package com.todaysfail.domains.tag.repository;
 
 import com.todaysfail.domains.tag.domain.Tag;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     Optional<Tag> findByTagName(String tagName);
+
+    List<Tag> findTop5ByTagNameContainsIgnoreCase(String searchKeyword);
+
+    List<Tag> findTop5ByOrderByUsedCountDesc();
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/service/TagDomainService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/service/TagDomainService.java
@@ -1,0 +1,17 @@
+package com.todaysfail.domains.tag.service;
+
+import com.todaysfail.aop.lock.RedissonLock;
+import com.todaysfail.domains.tag.domain.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TagDomainService {
+
+    @RedissonLock(lockName = "태그사용수증가", identifier = "tag")
+    public Tag increaseUsedCount(Tag tag) {
+        tag.increaseUsedCount();
+        return tag;
+    }
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureRegisterUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureRegisterUseCase.java
@@ -38,7 +38,7 @@ public class FailureRegisterUseCase {
                         .tags(tags.stream().map(Tag::getId).collect(Collectors.toList()))
                         .secret(request.secret())
                         .build();
-        Failure registeredFailure = failureDomainService.register(failure, category);
+        Failure registeredFailure = failureDomainService.register(failure, category, tags);
         return failureMapper.toFailureResponse(registeredFailure);
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/TagController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/TagController.java
@@ -1,0 +1,40 @@
+package com.todaysfail.api.web.tag;
+
+import com.todaysfail.api.web.tag.dto.response.TagResponse;
+import com.todaysfail.api.web.tag.usecase.TagPopularUseCase;
+import com.todaysfail.api.web.tag.usecase.TagSearchUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "7. [태그]")
+@RestController
+@RequestMapping("/api/v1/tags")
+@SecurityRequirement(name = "access-token")
+@RequiredArgsConstructor
+public class TagController {
+    private final TagSearchUseCase tagSearchUseCase;
+    private final TagPopularUseCase tagPopularUseCase;
+
+    @Operation(summary = "태그를 검색합니다. (5개)")
+    @GetMapping("/search")
+    public List<TagResponse> search(@RequestParam String searchKeyword) {
+        return tagSearchUseCase.execute(searchKeyword);
+    }
+
+    @Operation(summary = "많이 사용된 태그를 조회합니다. (5개)")
+    @GetMapping("/popular")
+    public List<TagResponse> popular() {
+        return tagPopularUseCase.execute();
+    }
+
+    // @Operation(summary = "추천 태그를 조회합니다.")
+    // @GetMapping("/recommend")
+    // TODO: 추천 태그 조회 API 구현
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/dto/response/TagResponse.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/dto/response/TagResponse.java
@@ -2,8 +2,8 @@ package com.todaysfail.api.web.tag.dto.response;
 
 import com.todaysfail.domains.tag.domain.Tag;
 
-public record TagResponse(Long tagId, String tagName) {
+public record TagResponse(Long tagId, String tagName, Long usedCount) {
     public static TagResponse from(Tag tag) {
-        return new TagResponse(tag.getId(), tag.getTagName());
+        return new TagResponse(tag.getId(), tag.getTagName(), tag.getUsedCount());
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/mapper/TagMapper.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/mapper/TagMapper.java
@@ -3,16 +3,16 @@ package com.todaysfail.api.web.tag.mapper;
 import com.todaysfail.api.web.tag.dto.response.TagResponse;
 import com.todaysfail.common.annotation.Mapper;
 import com.todaysfail.domains.tag.domain.Tag;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper
 public class TagMapper {
     public TagResponse toTagResponse(Tag tag) {
-        return new TagResponse(tag.getId(), tag.getTagName());
+        return TagResponse.from(tag);
     }
 
-    public Set<TagResponse> toTagResponseSet(Set<Tag> tagSet) {
-        return tagSet.stream().map(this::toTagResponse).collect(Collectors.toSet());
+    public List<TagResponse> toTagResponseList(List<Tag> tagList) {
+        return tagList.stream().map(this::toTagResponse).collect(Collectors.toList());
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/TagPopularUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/TagPopularUseCase.java
@@ -1,0 +1,21 @@
+package com.todaysfail.api.web.tag.usecase;
+
+import com.todaysfail.api.web.tag.dto.response.TagResponse;
+import com.todaysfail.api.web.tag.mapper.TagMapper;
+import com.todaysfail.common.annotation.UseCase;
+import com.todaysfail.domains.tag.domain.Tag;
+import com.todaysfail.domains.tag.port.TagQueryPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class TagPopularUseCase {
+    private final TagMapper tagMapper;
+    private final TagQueryPort tagQueryPort;
+
+    public List<TagResponse> execute() {
+        List<Tag> popularTagList = tagQueryPort.queryPopular();
+        return tagMapper.toTagResponseList(popularTagList);
+    }
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/TagSearchUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/TagSearchUseCase.java
@@ -1,0 +1,21 @@
+package com.todaysfail.api.web.tag.usecase;
+
+import com.todaysfail.api.web.tag.dto.response.TagResponse;
+import com.todaysfail.api.web.tag.mapper.TagMapper;
+import com.todaysfail.common.annotation.UseCase;
+import com.todaysfail.domains.tag.domain.Tag;
+import com.todaysfail.domains.tag.port.TagQueryPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class TagSearchUseCase {
+    private final TagMapper tagMapper;
+    private final TagQueryPort tagQueryPort;
+
+    public List<TagResponse> execute(String searchKeyword) {
+        List<Tag> tagList = tagQueryPort.querySearch(searchKeyword);
+        return tagMapper.toTagResponseList(tagList);
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #108 
### 작업내용
- 태그 검색(5개)
- 많이 사용된 태그 조회(5개)
- 많이 사용된 태그를 조회하기 위해 Tag에 usedCount 필드 추가
- 태그 수 카운트 동시성 제어를 위해 RedissionLock 사용

추천 태그 조회는 프로젝트 우선순위에 따라 추 후 구현 예정