### PR TITLE
[#125] feat: 태그 이름 최대길이 Validation 추가

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/domain/Tag.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/domain/Tag.java
@@ -1,6 +1,7 @@
 package com.todaysfail.domains.tag.domain;
 
 import com.todaysfail.common.BaseTimeEntity;
+import com.todaysfail.domains.tag.exception.TagNameLengthExceedException;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -18,6 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Tag extends BaseTimeEntity {
+    private static final int MAX_TAG_NAME_LENGTH = 23;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id")
@@ -33,5 +36,11 @@ public class Tag extends BaseTimeEntity {
 
     public void increaseUsedCount() {
         this.usedCount++;
+    }
+
+    public void validateTagNameLength() {
+        if (this.tagName.length() > MAX_TAG_NAME_LENGTH) {
+            throw TagNameLengthExceedException.EXCEPTION;
+        }
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/exception/TagErrorCode.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/exception/TagErrorCode.java
@@ -16,7 +16,11 @@ public enum TagErrorCode implements BaseErrorCode {
     TAG_COUNT_EXCEED(TodaysFailConst.BAD_REQUEST, "TAG_400_1", "허용된 최대 태그 개수를 초과했습니다."),
 
     @ExplainError("태그를 찾을 수 없습니다.")
-    TAG_NOT_FOUND(TodaysFailConst.BAD_REQUEST, "TAG_400_2", "태그를 찾을 수 없습니다.");
+    TAG_NOT_FOUND(TodaysFailConst.BAD_REQUEST, "TAG_400_2", "태그를 찾을 수 없습니다."),
+
+    @ExplainError("태그 이름의 길이 제한을 초과했습니다.")
+    TAG_NAME_LENGTH_EXCEED(TodaysFailConst.BAD_REQUEST, "TAG_400_3", "태그 이름의 길이 제한을 초과했습니다."),
+    ;
 
     private Integer status;
     private String code;

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/exception/TagNameLengthExceedException.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/exception/TagNameLengthExceedException.java
@@ -1,0 +1,11 @@
+package com.todaysfail.domains.tag.exception;
+
+import com.todaysfail.common.exception.TodaysFailCodeException;
+
+public class TagNameLengthExceedException extends TodaysFailCodeException {
+    public static final TodaysFailCodeException EXCEPTION = new TagNameLengthExceedException();
+
+    public TagNameLengthExceedException() {
+        super(TagErrorCode.TAG_NAME_LENGTH_EXCEED);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/service/TagDomainService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/tag/service/TagDomainService.java
@@ -2,16 +2,28 @@ package com.todaysfail.domains.tag.service;
 
 import com.todaysfail.aop.lock.RedissonLock;
 import com.todaysfail.domains.tag.domain.Tag;
+import com.todaysfail.domains.tag.port.TagCommandPort;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TagDomainService {
+    private final TagCommandPort tagCommandPort;
 
     @RedissonLock(lockName = "태그사용수증가", identifier = "tag")
     public Tag increaseUsedCount(Tag tag) {
         tag.increaseUsedCount();
         return tag;
+    }
+
+    @Transactional
+    public List<Tag> saveAndRetrieveAllTags(Set<String> tagNameSet) {
+        List<Tag> tags = tagCommandPort.saveAndRetrieveAllTags(tagNameSet);
+        tags.stream().forEach(tag -> tag.validateTagNameLength());
+        return tags;
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureRegisterUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureRegisterUseCase.java
@@ -10,22 +10,24 @@ import com.todaysfail.domains.category.port.CategoryQueryPort;
 import com.todaysfail.domains.failure.domain.Failure;
 import com.todaysfail.domains.failure.service.FailureDomainService;
 import com.todaysfail.domains.tag.domain.Tag;
-import com.todaysfail.domains.tag.port.TagCommandPort;
+import com.todaysfail.domains.tag.service.TagDomainService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
 public class FailureRegisterUseCase {
     private final FailureMapper failureMapper;
-    private final TagCommandPort tagCommandPort;
     private final CategoryQueryPort categoryQueryPort;
     private final FailureDomainService failureDomainService;
+    private final TagDomainService tagDomainService;
 
+    @Transactional
     public FailureResponse execute(FailureRegisterRequest request) {
         Long currentUserId = SecurityUtils.getCurrentUserId();
-        List<Tag> tags = tagCommandPort.saveAndRetrieveAllTags(request.tagNameSet());
+        List<Tag> tags = tagDomainService.saveAndRetrieveAllTags(request.tagNameSet());
         Category category = categoryQueryPort.queryCategory(request.categoryId());
         Failure failure =
                 Failure.builder()


### PR DESCRIPTION
### 연관 이슈
- close #125 
### 작업내용
- entity 내부에 `MAX_TAG_NAME_LENGTH` 상수 선언하여 validation 메소드 추가
- FaliureRegisterUseCase에서 CommandPort 대신 TagDomainService 사용

![image](https://github.com/TodaysFail/TodaysFail-Backend/assets/64088250/376a8524-683a-44da-a1c5-c72af96a7128)
해당 영역 최소너비에서 최대 길이로 제한