### PR TITLE
[#127] feat: 실패 내역과 카테고리가 존재하지 않는지 확인

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureQueryAdapter.java
@@ -4,6 +4,7 @@ import com.todaysfail.common.annotation.Adapter;
 import com.todaysfail.domains.failure.domain.Failure;
 import com.todaysfail.domains.failure.port.FailureQueryPort;
 import com.todaysfail.domains.failure.repository.FailureRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -18,5 +19,10 @@ public class FailureQueryAdapter implements FailureQueryPort {
     @Override
     public Slice<Failure> queryFeed(Pageable pageable) {
         return failureRepository.findAllBySecretFalseOrderByFailureDateDesc(pageable);
+    }
+
+    @Override
+    public List<Failure> queryFailureByUserId(Long userId) {
+        return failureRepository.findAllByUserId(userId);
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureQueryPort.java
@@ -1,9 +1,12 @@
 package com.todaysfail.domains.failure.port;
 
 import com.todaysfail.domains.failure.domain.Failure;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface FailureQueryPort {
     Slice<Failure> queryFeed(Pageable pageable);
+
+    List<Failure> queryFailureByUserId(Long userId);
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/repository/FailureRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/repository/FailureRepository.java
@@ -1,10 +1,13 @@
 package com.todaysfail.domains.failure.repository;
 
 import com.todaysfail.domains.failure.domain.Failure;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FailureRepository extends JpaRepository<Failure, Long> {
     Slice<Failure> findAllBySecretFalseOrderByFailureDateDesc(Pageable pageable);
+
+    List<Failure> findAllByUserId(Long userId);
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/UserController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/UserController.java
@@ -2,6 +2,7 @@ package com.todaysfail.api.web.user;
 
 import com.todaysfail.api.web.user.dto.response.RandomNicknameResponse;
 import com.todaysfail.api.web.user.usecase.RandomNicknameUseCase;
+import com.todaysfail.api.web.user.usecase.UserFirstTimeCheckUseCase;
 import com.todaysfail.api.web.user.usecase.UserQueryUseCase;
 import com.todaysfail.api.web.user.usecase.UserWithDrawUseCase;
 import com.todaysfail.common.annotation.DisableSwaggerSecurity;
@@ -24,6 +25,7 @@ public class UserController {
     private final UserQueryUseCase userQueryUseCase;
     private final RandomNicknameUseCase randomNicknameUseCase;
     private final UserWithDrawUseCase userWithDrawUseCase;
+    private final UserFirstTimeCheckUseCase userFirstTimeCheckUseCase;
 
     @SecurityRequirement(name = "access-token")
     @Operation(summary = "내 정보를 조회합니다.")
@@ -44,5 +46,11 @@ public class UserController {
     @GetMapping("/nickname/generate")
     public RandomNicknameResponse generateRandomNickname() {
         return randomNicknameUseCase.execute();
+    }
+
+    @Operation(summary = "생성 된 카테고리와 실패기록이 없는지 확인합니다.")
+    @GetMapping("/check-first")
+    public boolean checkIfFirstTimeUser() {
+        return userFirstTimeCheckUseCase.execute();
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/usecase/UserFirstTimeCheckUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/user/usecase/UserFirstTimeCheckUseCase.java
@@ -1,0 +1,32 @@
+package com.todaysfail.api.web.user.usecase;
+
+import com.todaysfail.common.annotation.UseCase;
+import com.todaysfail.config.security.SecurityUtils;
+import com.todaysfail.domains.category.domain.Category;
+import com.todaysfail.domains.category.port.CategoryQueryPort;
+import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.failure.port.FailureQueryPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class UserFirstTimeCheckUseCase {
+    private final CategoryQueryPort categoryQueryPort;
+    private final FailureQueryPort failureQueryPort;
+
+    public boolean execute() {
+        final Long userId = SecurityUtils.getCurrentUserId();
+        List<Category> categories = categoryQueryPort.queryCategoryByUserId(userId);
+        if (!categories.isEmpty()) {
+            return false;
+        }
+
+        List<Failure> failures = failureQueryPort.queryFailureByUserId(userId);
+        if (!failures.isEmpty()) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #127 
### 작업내용
- 유저가 생성한 카테고리와 실패 기록이 존재하지 않을 경우 defaulut view를 보여주기 위한 check API
![main_defaulut](https://github.com/TodaysFail/TodaysFail-Backend/assets/64088250/3df6b461-edd6-4416-a368-599d89efa007)
