### PR TITLE
[#131] feat: 유저 태그 히스토리 기능 추가

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/adpater/UserTagHistoryCommandAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/adpater/UserTagHistoryCommandAdapter.java
@@ -1,0 +1,18 @@
+package com.todaysfail.domains.usertaghistory.adpater;
+
+import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+import com.todaysfail.domains.usertaghistory.port.UserTagHistoryCommandPort;
+import com.todaysfail.domains.usertaghistory.repository.UserTagHistoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class UserTagHistoryCommandAdapter implements UserTagHistoryCommandPort {
+    private final UserTagHistoryRepository userTagHistoryRepository;
+
+    @Override
+    public UserTagHistory save(UserTagHistory userTagHistory) {
+        return userTagHistoryRepository.save(userTagHistory);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/adpater/UserTagHistoryQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/adpater/UserTagHistoryQueryAdapter.java
@@ -1,0 +1,9 @@
+package com.todaysfail.domains.usertaghistory.adpater;
+
+import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.usertaghistory.port.UserTagHistoryQueryPort;
+import lombok.RequiredArgsConstructor;
+
+@Adapter
+@RequiredArgsConstructor
+public class UserTagHistoryQueryAdapter implements UserTagHistoryQueryPort {}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/adpater/UserTagHistoryQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/adpater/UserTagHistoryQueryAdapter.java
@@ -1,9 +1,19 @@
 package com.todaysfail.domains.usertaghistory.adpater;
 
 import com.todaysfail.common.annotation.Adapter;
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
 import com.todaysfail.domains.usertaghistory.port.UserTagHistoryQueryPort;
+import com.todaysfail.domains.usertaghistory.repository.UserTagHistoryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @Adapter
 @RequiredArgsConstructor
-public class UserTagHistoryQueryAdapter implements UserTagHistoryQueryPort {}
+public class UserTagHistoryQueryAdapter implements UserTagHistoryQueryPort {
+    private final UserTagHistoryRepository userTagHistoryRepository;
+
+    @Override
+    public List<UserTagHistory> queryUserTagHistory(Long userId) {
+        return userTagHistoryRepository.findTop5ByUserIdOrderByCreatedAtDesc(userId);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/domain/UserTagHistory.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/domain/UserTagHistory.java
@@ -1,0 +1,33 @@
+package com.todaysfail.domains.usertaghistory.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity(name = "tbl_user_tag_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserTagHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_tag_history_id")
+    private Long id;
+
+    private Long userId;
+
+    private Long tagId;
+
+    public static UserTagHistory registerUserTagHistory(Long userId, Long tagId) {
+        return new UserTagHistory(null, userId, tagId);
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/domain/UserTagHistory.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/domain/UserTagHistory.java
@@ -1,5 +1,6 @@
 package com.todaysfail.domains.usertaghistory.domain;
 
+import com.todaysfail.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "tbl_user_tag_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserTagHistory {
+public class UserTagHistory extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/port/UserTagHistoryCommandPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/port/UserTagHistoryCommandPort.java
@@ -1,0 +1,7 @@
+package com.todaysfail.domains.usertaghistory.port;
+
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+
+public interface UserTagHistoryCommandPort {
+    UserTagHistory save(UserTagHistory userTagHistory);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/port/UserTagHistoryQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/port/UserTagHistoryQueryPort.java
@@ -1,0 +1,3 @@
+package com.todaysfail.domains.usertaghistory.port;
+
+public interface UserTagHistoryQueryPort {}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/port/UserTagHistoryQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/port/UserTagHistoryQueryPort.java
@@ -1,3 +1,8 @@
 package com.todaysfail.domains.usertaghistory.port;
 
-public interface UserTagHistoryQueryPort {}
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+import java.util.List;
+
+public interface UserTagHistoryQueryPort {
+    List<UserTagHistory> queryUserTagHistory(Long userId);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/repository/UserTagHistoryRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/repository/UserTagHistoryRepository.java
@@ -1,6 +1,9 @@
 package com.todaysfail.domains.usertaghistory.repository;
 
 import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserTagHistoryRepository extends JpaRepository<UserTagHistory, Long> {}
+public interface UserTagHistoryRepository extends JpaRepository<UserTagHistory, Long> {
+    List<UserTagHistory> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/repository/UserTagHistoryRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/usertaghistory/repository/UserTagHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.todaysfail.domains.usertaghistory.repository;
+
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTagHistoryRepository extends JpaRepository<UserTagHistory, Long> {}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureRegisterUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureRegisterUseCase.java
@@ -11,6 +11,8 @@ import com.todaysfail.domains.failure.domain.Failure;
 import com.todaysfail.domains.failure.service.FailureDomainService;
 import com.todaysfail.domains.tag.domain.Tag;
 import com.todaysfail.domains.tag.service.TagDomainService;
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+import com.todaysfail.domains.usertaghistory.port.UserTagHistoryCommandPort;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class FailureRegisterUseCase {
     private final CategoryQueryPort categoryQueryPort;
     private final FailureDomainService failureDomainService;
     private final TagDomainService tagDomainService;
+    private final UserTagHistoryCommandPort userTagHistoryCommandPort;
 
     @Transactional
     public FailureResponse execute(FailureRegisterRequest request) {
@@ -41,6 +44,9 @@ public class FailureRegisterUseCase {
                         .secret(request.secret())
                         .build();
         Failure registeredFailure = failureDomainService.register(failure, category, tags);
+        tags.stream()
+                .map(tag -> UserTagHistory.registerUserTagHistory(currentUserId, tag.getId()))
+                .forEach(userTagHistoryCommandPort::save);
         return failureMapper.toFailureResponse(registeredFailure);
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/TagController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/TagController.java
@@ -3,6 +3,7 @@ package com.todaysfail.api.web.tag;
 import com.todaysfail.api.web.tag.dto.response.TagResponse;
 import com.todaysfail.api.web.tag.usecase.TagPopularUseCase;
 import com.todaysfail.api.web.tag.usecase.TagSearchUseCase;
+import com.todaysfail.api.web.tag.usecase.UserTagHistoryQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TagController {
     private final TagSearchUseCase tagSearchUseCase;
     private final TagPopularUseCase tagPopularUseCase;
+    private final UserTagHistoryQueryUseCase userTagHistoryQueryUseCase;
 
     @Operation(summary = "태그를 검색합니다. (5개)")
     @GetMapping("/search")
@@ -37,4 +39,10 @@ public class TagController {
     // @Operation(summary = "추천 태그를 조회합니다.")
     // @GetMapping("/recommend")
     // TODO: 추천 태그 조회 API 구현
+
+    @Operation(summary = "유저 태그 히스토리를 조회합니다. (5개)")
+    @GetMapping("/history")
+    public List<TagResponse> userTagHistory() {
+        return userTagHistoryQueryUseCase.execute();
+    }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/UserTagHistoryQueryUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/UserTagHistoryQueryUseCase.java
@@ -1,0 +1,29 @@
+package com.todaysfail.api.web.tag.usecase;
+
+import com.todaysfail.api.web.tag.dto.response.TagResponse;
+import com.todaysfail.api.web.tag.mapper.TagMapper;
+import com.todaysfail.common.annotation.UseCase;
+import com.todaysfail.config.security.SecurityUtils;
+import com.todaysfail.domains.tag.domain.Tag;
+import com.todaysfail.domains.tag.port.TagQueryPort;
+import com.todaysfail.domains.usertaghistory.domain.UserTagHistory;
+import com.todaysfail.domains.usertaghistory.port.UserTagHistoryQueryPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class UserTagHistoryQueryUseCase {
+    private final TagMapper tagMapper;
+    private final UserTagHistoryQueryPort userTagHistoryQueryPort;
+    private final TagQueryPort tagQueryPort;
+
+    public List<TagResponse> execute() {
+        final Long userId = SecurityUtils.getCurrentUserId();
+        List<UserTagHistory> userTagHistories = userTagHistoryQueryPort.queryUserTagHistory(userId);
+        List<Tag> tags =
+                tagQueryPort.queryAllByIds(
+                        userTagHistories.stream().map(UserTagHistory::getTagId).toList());
+        return tagMapper.toTagResponseList(tags);
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #131 
### 작업내용
- UserTagHistory entity 생성
- 실패 등록시 UserTagHistory 저장
- UserTagHistory 조회 (5건)