### PR TITLE
[#133] feat: 선택 한 날짜의 실패 기록을 카테고리별로 조회

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/adapter/FailureQueryAdapter.java
@@ -4,6 +4,7 @@ import com.todaysfail.common.annotation.Adapter;
 import com.todaysfail.domains.failure.domain.Failure;
 import com.todaysfail.domains.failure.port.FailureQueryPort;
 import com.todaysfail.domains.failure.repository.FailureRepository;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -29,5 +30,10 @@ public class FailureQueryAdapter implements FailureQueryPort {
     @Override
     public List<Integer> queryDailyStatusByYearMonth(int year, int month) {
         return failureRepository.findDailyStatusByYearMonth(year, month);
+    }
+
+    @Override
+    public List<Failure> queryFailureByUserIdAndDate(Long userId, LocalDate date) {
+        return failureRepository.findAllByUserIdAndFailureDate(userId, date);
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/port/FailureQueryPort.java
@@ -1,6 +1,7 @@
 package com.todaysfail.domains.failure.port;
 
 import com.todaysfail.domains.failure.domain.Failure;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,4 +12,6 @@ public interface FailureQueryPort {
     List<Failure> queryFailureByUserId(Long userId);
 
     List<Integer> queryDailyStatusByYearMonth(int year, int month);
+
+    List<Failure> queryFailureByUserIdAndDate(Long userId, LocalDate date);
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/repository/FailureRepository.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/repository/FailureRepository.java
@@ -1,6 +1,7 @@
 package com.todaysfail.domains.failure.repository;
 
 import com.todaysfail.domains.failure.domain.Failure;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -18,4 +19,6 @@ public interface FailureRepository extends JpaRepository<Failure, Long> {
                     + "and month(f.failureDate) = :month "
                     + "group by DAY(f.failureDate)")
     List<Integer> findDailyStatusByYearMonth(int year, int month);
+
+    List<Failure> findAllByUserIdAndFailureDate(Long userId, LocalDate date);
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/FailureController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/FailureController.java
@@ -2,8 +2,10 @@ package com.todaysfail.api.web.failure;
 
 import com.todaysfail.api.web.common.SliceResponse;
 import com.todaysfail.api.web.failure.dto.request.FailureRegisterRequest;
+import com.todaysfail.api.web.failure.dto.response.FailureByCategoryResponse;
 import com.todaysfail.api.web.failure.dto.response.FailureMonthlyDailyStatusResponse;
 import com.todaysfail.api.web.failure.dto.response.FailureResponse;
+import com.todaysfail.api.web.failure.usecase.FailureByCategoryQueryUseCase;
 import com.todaysfail.api.web.failure.usecase.FailureFeedQueryUseCase;
 import com.todaysfail.api.web.failure.usecase.FailureLikeUseCase;
 import com.todaysfail.api.web.failure.usecase.FailureMonthlyDailyStatusUseCase;
@@ -11,12 +13,14 @@ import com.todaysfail.api.web.failure.usecase.FailureRegisterUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +39,7 @@ public class FailureController {
     private final FailureFeedQueryUseCase failureFeedQueryUseCase;
     private final FailureLikeUseCase failureLikeUseCase;
     private final FailureMonthlyDailyStatusUseCase failureMonthlyDailyStatusUseCase;
+    private final FailureByCategoryQueryUseCase failureByCategoryQueryUseCase;
 
     @Operation(summary = "실패 등록")
     @PostMapping
@@ -59,5 +64,12 @@ public class FailureController {
     @GetMapping("/monthly-daily-status")
     public FailureMonthlyDailyStatusResponse checkMonthFailures(@RequestParam YearMonth yearMonth) {
         return failureMonthlyDailyStatusUseCase.execute(yearMonth);
+    }
+
+    @Operation(summary = "선택 한 날짜의 실패 기록을 카테고리별로 조회")
+    @GetMapping("/{date}")
+    public FailureByCategoryResponse getFailures(
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return failureByCategoryQueryUseCase.execute(date);
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/dto/response/FailureByCategoryResponse.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/dto/response/FailureByCategoryResponse.java
@@ -1,0 +1,6 @@
+package com.todaysfail.api.web.failure.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+public record FailureByCategoryResponse(Map<Long, List<FailureResponse>> response) {}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/mapper/FailureMapper.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/mapper/FailureMapper.java
@@ -12,6 +12,7 @@ import com.todaysfail.domains.tag.port.TagQueryPort;
 import com.todaysfail.domains.user.domain.User;
 import com.todaysfail.domains.user.port.UserQueryPort;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 
@@ -33,5 +34,11 @@ public class FailureMapper {
 
     public SliceResponse<FailureResponse> toFailureSliceResponse(Slice<Failure> failureSlice) {
         return SliceResponse.of(failureSlice.map(failure -> toFailureResponse(failure)));
+    }
+
+    public List<FailureResponse> toFailureListResponse(List<Failure> failures) {
+        return failures.stream()
+                .map(failure -> toFailureResponse(failure))
+                .collect(Collectors.toList());
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureByCategoryQueryUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/failure/usecase/FailureByCategoryQueryUseCase.java
@@ -1,0 +1,33 @@
+package com.todaysfail.api.web.failure.usecase;
+
+import com.todaysfail.api.web.failure.dto.response.FailureByCategoryResponse;
+import com.todaysfail.api.web.failure.dto.response.FailureResponse;
+import com.todaysfail.api.web.failure.mapper.FailureMapper;
+import com.todaysfail.common.annotation.UseCase;
+import com.todaysfail.config.security.SecurityUtils;
+import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.failure.port.FailureQueryPort;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class FailureByCategoryQueryUseCase {
+    private final FailureMapper failureMapper;
+    private final FailureQueryPort failureQueryPort;
+
+    public FailureByCategoryResponse execute(final LocalDate date) {
+        final Long userId = SecurityUtils.getCurrentUserId();
+        List<Failure> failures = failureQueryPort.queryFailureByUserIdAndDate(userId, date);
+        Map<Long, List<FailureResponse>> map =
+                failureMapper.toFailureListResponse(failures).stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        failureResponse ->
+                                                failureResponse.category().categoryId()));
+        return new FailureByCategoryResponse(map);
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #133 
### 작업내용
- PathVariable을 통해 LocalDate를 받아 해당 날짜에 기록 된 실패 기록들을 불러옵니다.
- 실패 기록들을 카테고리 별로 그룹핑