### PR TITLE
[#137] fix: findByOauthInfo Optional로 변경

### DIFF
--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/adapter/UserQueryAdapter.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/adapter/UserQueryAdapter.java
@@ -6,6 +6,7 @@ import com.todaysfail.domains.user.domain.User;
 import com.todaysfail.domains.user.exception.UserNotFountException;
 import com.todaysfail.domains.user.port.UserQueryPort;
 import com.todaysfail.domains.user.repository.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,10 +17,8 @@ public class UserQueryAdapter implements UserQueryPort {
     private final UserRepository userRepository;
 
     @Override
-    public User findByOauthInfo(OauthInfo oauthInfo) {
-        return userRepository
-                .findByOauthInfo(oauthInfo)
-                .orElseThrow(() -> UserNotFountException.EXCEPTION);
+    public Optional<User> findByOauthInfo(OauthInfo oauthInfo) {
+        return userRepository.findByOauthInfo(oauthInfo);
     }
 
     @Override

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/port/UserQueryPort.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/port/UserQueryPort.java
@@ -2,9 +2,10 @@ package com.todaysfail.domains.user.port;
 
 import com.todaysfail.domains.user.domain.OauthInfo;
 import com.todaysfail.domains.user.domain.User;
+import java.util.Optional;
 
 public interface UserQueryPort {
-    User findByOauthInfo(OauthInfo oauthInfo);
+    Optional<User> findByOauthInfo(OauthInfo oauthInfo);
 
     Boolean existsByOauthInfo(OauthInfo oauthInfo);
 

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserDomainService.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/user/service/UserDomainService.java
@@ -18,6 +18,7 @@ import com.todaysfail.domains.user.exception.NicknameGenerationFailedException;
 import com.todaysfail.domains.user.exception.UserNotFountException;
 import com.todaysfail.domains.user.port.UserCommandPort;
 import com.todaysfail.domains.user.port.UserQueryPort;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,12 +42,12 @@ public class UserDomainService {
     @Transactional(noRollbackFor = UserNotFountException.class)
     @RedissonLock(lockName = "개발용회원가입", identifier = "oauthInfo")
     public User upsert(Profile profile, OauthInfo oauthInfo, FcmNotification fcmNotification) {
-        try {
-            return userQueryPort.findByOauthInfo(oauthInfo);
-        } catch (UserNotFountException e) {
+        Optional<User> userOptional = userQueryPort.findByOauthInfo(oauthInfo);
+        if (userOptional.isEmpty()) {
             return userCommandPort.save(
                     User.registerNormalUser(profile, oauthInfo, fcmNotification));
         }
+        return userOptional.get();
     }
 
     @Transactional


### PR DESCRIPTION
### 연관 이슈
- close #137
### 작업내용
upsert를 구현하기 위해 Domain Service에서 `@Transactional`을 사용하고,
try catch로 UserNotFoundException을 catch 하였으나,
port 내에서 exception 발생하면서 롤백 마킹 되어,
원래 진행되고있는 메소드에서 catch 하여도 롤백이 되는 현상 발생.


[관련하여 찾아](https://keencho.github.io/posts/transaction-rollback/)보고 noRollbackFor을 적용하였으나 해결되지 않아 우선 Optional로 처리 