### PR TITLE
[#143] fix: 데이터베이스 레플리케이션 prod 환경에서만 적용

### DIFF
--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReadOnlyDataSourceCycle.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReadOnlyDataSourceCycle.java
@@ -3,7 +3,7 @@ package com.todaysfail.config.mysql;
 import java.util.List;
 import org.springframework.context.annotation.Profile;
 
-@Profile({"prod", "dev"})
+@Profile("prod")
 public class ReadOnlyDataSourceCycle<T> {
     private List<T> readOnlyDataSourceLookupKeys;
     private int index = 0;

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationDataSourceConfiguration.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationDataSourceConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile({"prod", "dev"})
+@Profile("prod")
 public class ReplicationDataSourceConfiguration {
     private final ReplicationDataSourceProperties replicationDataSourceProperties;
 

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationRoutingDataSource.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/mysql/ReplicationRoutingDataSource.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Profile({"prod", "dev"})
+@Profile("prod")
 @RequiredArgsConstructor
 public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
     private static final String MASTER = "master";


### PR DESCRIPTION
### 연관 이슈
- close #143
### 작업내용
- 기존 데이터베이스 이중화되어있었는데, 비용문제로 인해 prod 환경에서만 적용하도록 변경