### PR TITLE
[#142] feat: Sorted set으로 인기 태그 기능 구현

### DIFF
--- a/TodaysFail-Common/src/main/java/com/todaysfail/common/consts/TodaysFailConst.java
+++ b/TodaysFail-Common/src/main/java/com/todaysfail/common/consts/TodaysFailConst.java
@@ -12,6 +12,7 @@ public class TodaysFailConst {
     public static final String TOKEN_ISSUER = "TodaysFail";
     public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
     public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+    public static final String RECOMMEND_TAG_KEY = "RecommendTag";
 
     public static final int MILLI_TO_SECOND = 1000;
     public static final int SERVICE_UNAVAILABLE = 503;

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/domain/Failure.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/domains/failure/domain/Failure.java
@@ -1,8 +1,10 @@
 package com.todaysfail.domains.failure.domain;
 
+import com.todaysfail.aop.event.Events;
 import com.todaysfail.common.BaseTimeEntity;
 import com.todaysfail.config.converter.LongArrayConverter;
 import com.todaysfail.domains.failure.exception.FailureNotOwnedByUserException;
+import com.todaysfail.events.FailureRegisterEvent;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +14,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.PostPersist;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,6 +50,11 @@ public class Failure extends BaseTimeEntity {
     private int heartCount;
 
     private boolean secret;
+
+    @PostPersist
+    void registerEvent() {
+        Events.raise(new FailureRegisterEvent(this));
+    }
 
     public boolean isMine(Long userId) {
         return this.userId.equals(userId);

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/events/FailureRegisterEvent.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/events/FailureRegisterEvent.java
@@ -1,0 +1,14 @@
+package com.todaysfail.events;
+
+import com.todaysfail.aop.event.DomainEvent;
+import com.todaysfail.domains.failure.domain.Failure;
+import lombok.Getter;
+
+@Getter
+public class FailureRegisterEvent extends DomainEvent {
+    private final Failure failure;
+
+    public FailureRegisterEvent(Failure failure) {
+        this.failure = failure;
+    }
+}

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/events/handler/FailureRegisterEventHandler.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/events/handler/FailureRegisterEventHandler.java
@@ -1,5 +1,7 @@
 package com.todaysfail.events.handler;
 
+import static com.todaysfail.common.consts.TodaysFailConst.RECOMMEND_TAG_KEY;
+
 import com.todaysfail.common.annotation.EventHandler;
 import com.todaysfail.domains.failure.domain.Failure;
 import com.todaysfail.domains.tag.domain.Tag;
@@ -36,7 +38,7 @@ public class FailureRegisterEventHandler {
                         tag -> {
                             redisTemplate
                                     .opsForZSet()
-                                    .incrementScore("RecommendTag", tag.getTagName(), 1);
+                                    .incrementScore(RECOMMEND_TAG_KEY, tag.getTagName(), 1);
                         });
     }
 }

--- a/TodaysFail-Domain/src/main/java/com/todaysfail/events/handler/FailureRegisterEventHandler.java
+++ b/TodaysFail-Domain/src/main/java/com/todaysfail/events/handler/FailureRegisterEventHandler.java
@@ -1,0 +1,32 @@
+package com.todaysfail.events.handler;
+
+import com.todaysfail.common.annotation.EventHandler;
+import com.todaysfail.domains.failure.domain.Failure;
+import com.todaysfail.domains.tag.domain.Tag;
+import com.todaysfail.domains.tag.port.TagQueryPort;
+import com.todaysfail.events.FailureRegisterEvent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@EventHandler
+@RequiredArgsConstructor
+public class FailureRegisterEventHandler {
+    private final TagQueryPort tagQueryPort;
+
+    @Async
+    @TransactionalEventListener(
+            classes = FailureRegisterEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserRegisterEvent(FailureRegisterEvent event) {
+        final Failure failure = event.getFailure();
+        List<Long> tagIds = failure.getTags();
+        List<Tag> tags = tagQueryPort.queryAllByIds(tagIds);
+
+        log.info("[DOMAIN EVENT : FailureRegisterEvent] {}", event);
+    }
+}

--- a/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/redis/RedisCacheConfig.java
+++ b/TodaysFail-Infrastructure/src/main/java/com/todaysfail/config/redis/RedisCacheConfig.java
@@ -8,7 +8,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -31,5 +33,15 @@ public class RedisCacheConfig {
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
                 .cacheDefaults(redisCacheConfiguration)
                 .build();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return redisTemplate;
     }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/TagController.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/TagController.java
@@ -1,7 +1,9 @@
 package com.todaysfail.api.web.tag;
 
+import com.todaysfail.api.web.tag.dto.response.TagRecommendResponse;
 import com.todaysfail.api.web.tag.dto.response.TagResponse;
 import com.todaysfail.api.web.tag.usecase.TagPopularUseCase;
+import com.todaysfail.api.web.tag.usecase.TagRecommendUseCase;
 import com.todaysfail.api.web.tag.usecase.TagSearchUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TagController {
     private final TagSearchUseCase tagSearchUseCase;
     private final TagPopularUseCase tagPopularUseCase;
+    private final TagRecommendUseCase tagRecommendUseCase;
 
     @Operation(summary = "태그를 검색합니다. (5개)")
     @GetMapping("/search")
@@ -34,7 +37,9 @@ public class TagController {
         return tagPopularUseCase.execute();
     }
 
-    // @Operation(summary = "추천 태그를 조회합니다.")
-    // @GetMapping("/recommend")
-    // TODO: 추천 태그 조회 API 구현
+    @Operation(summary = "추천 태그를 조회합니다.")
+    @GetMapping("/recommend")
+    public List<TagRecommendResponse> recommendTag() {
+        return tagRecommendUseCase.execute();
+    }
 }

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/dto/response/TagRecommendResponse.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/dto/response/TagRecommendResponse.java
@@ -1,0 +1,9 @@
+package com.todaysfail.api.web.tag.dto.response;
+
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+
+public record TagRecommendResponse(String tagName, double score) {
+    public static TagRecommendResponse from(TypedTuple<String> tuple) {
+        return new TagRecommendResponse(tuple.getValue(), tuple.getScore());
+    }
+}

--- a/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/TagRecommendUseCase.java
+++ b/TodaysFail-Interface/src/main/java/com/todaysfail/api/web/tag/usecase/TagRecommendUseCase.java
@@ -1,0 +1,26 @@
+package com.todaysfail.api.web.tag.usecase;
+
+import static com.todaysfail.common.consts.TodaysFailConst.RECOMMEND_TAG_KEY;
+
+import com.todaysfail.api.web.tag.dto.response.TagRecommendResponse;
+import com.todaysfail.common.annotation.UseCase;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+
+@UseCase
+@RequiredArgsConstructor
+public class TagRecommendUseCase {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public List<TagRecommendResponse> execute() {
+        String key = RECOMMEND_TAG_KEY;
+        ZSetOperations<String, String> ZSetOperations = redisTemplate.opsForZSet();
+        Set<TypedTuple<String>> typedTuples = ZSetOperations.reverseRangeWithScores(key, 0, 9);
+        return typedTuples.stream().map(TagRecommendResponse::from).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 연관 이슈
- close #142 
### 작업내용
- Redis Sorted Set을 활용하여 인기 태그를 구현
- score를 기반하여 정렬이 되고, ZSET에서 시간복잡도 O(1)로 해당하는 원소에 바로 접근할 수 있어 적용